### PR TITLE
Chatbot transition updates

### DIFF
--- a/docs/concepts/chatbots/index.md
+++ b/docs/concepts/chatbots/index.md
@@ -13,6 +13,6 @@
 
 
 ### Pipeline
-[Pipelines](../pipelines/index.md) allow you to create more complex bots by defining a ‘graph’ (in the computer science sense) of nodes. You can think of this graph as a workflow that flows from input to output. Each message to the bot is processed by the graph to produce a final output. A single response from the chatbot will be one successful path through the graph from the input node to the output node.
+[Pipelines](../pipelines/index.md) lets you build more advanced bots by defining a graph—a network of connected nodes representing different steps in a workflow. You can think of this graph as a flowchart that starts with user input and ends with the bot’s response. Each message sent to the bot follows a specific path through the graph to generate the final output.
 
-This can be useful if you want to build a complex bot that performs different tasks depending on the user’s request. Generally, trying to make a single bot prompt do multiple functions doesn’t work well so it is better to create multiple prompts for each task and then combine them using a Pipeline. This is similar to the Multi-bot setup but allows more flexibility and complexity.
+This approach is especially useful when you want your bot to handle different types of tasks based on the user’s request. Instead of forcing a single prompt to do everything (which can lead to more testing and building time), it’s better to create separate prompts for each function and link them together using a Pipeline. This concept is similar to the Multi-bot setup but offers greater flexibility and complexity.

--- a/docs/concepts/chatbots/index.md
+++ b/docs/concepts/chatbots/index.md
@@ -5,7 +5,7 @@
     We're excited to announce that Pipelines is now being rolled out across Open Chat Studio. This new feature will transform how you build and manage chatbots with several key improvements:
 
     - **Simplified Workflow**: Pipelines introduces a cleaner, more intuitive interface for building chatbots
-    - **Streamlined Bot Creation**: We're transitioning from the 'form-based' approach to make Pipelines the primary (and eventually only) method for bot creation
+    - **Streamlined Bot Building**: We're transitioning from the 'form-based' approach to make Pipelines the primary (and eventually only) method for bot building
     - **Seamless Transition**: All existing experiments will continue to work without disruption during this rollout
     - **Full Support Available**: The Dimagi team is ready to provide help and support as you explore this new feature
 

--- a/docs/concepts/chatbots/index.md
+++ b/docs/concepts/chatbots/index.md
@@ -1,0 +1,18 @@
+# Chatbots
+
+!!!info
+    ### Announcement: Pipelines Feature Rolling Out
+    We're excited to announce that Pipelines is now being rolled out across Open Chat Studio. This new feature will transform how you build and manage chatbots with several key improvements:
+
+    - **Simplified Workflow**: Pipelines introduces a cleaner, more intuitive interface for building chatbots
+    - **Streamlined Bot Creation**: We're transitioning from the 'form-based' approach to make Pipelines the primary (and eventually only) method for bot creation
+    - **Seamless Transition**: All existing experiments will continue to work without disruption during this rollout
+    - **Full Support Available**: The Dimagi team is ready to provide help and support as you explore this new feature
+
+    We look forward to seeing what you create with Pipelines!
+
+
+### Pipeline
+[Pipelines](../pipelines/index.md) allow you to create more complex bots by defining a ‘graph’ (in the computer science sense) of nodes. You can think of this graph as a workflow that flows from input to output. Each message to the bot is processed by the graph to produce a final output. A single response from the chatbot will be one successful path through the graph from the input node to the output node.
+
+This can be useful if you want to build a complex bot that performs different tasks depending on the user’s request. Generally, trying to make a single bot prompt do multiple functions doesn’t work well so it is better to create multiple prompts for each task and then combine them using a Pipeline. This is similar to the Multi-bot setup but allows more flexibility and complexity.

--- a/docs/concepts/chatbots/index.md
+++ b/docs/concepts/chatbots/index.md
@@ -1,18 +1,32 @@
 # Chatbots
 
 !!!info
-    ### Announcement: Pipelines Feature Rolling Out
-    We're excited to announce that Pipelines is now being rolled out across Open Chat Studio. This new feature will transform how you build and manage chatbots with several key improvements:
+    ### Announcement: Chatbots Feature Rolling Out
+    We are excited to announce that we are releasing a new way to build chatbots in Open Chat Studio. You may already be using 'Pipelines'
+    to build 'Experiments'. We are now transitioning to the term 'Chatbots' and away from 'Experiments'. This change is part of our ongoing effort to improve the user experience and make it easier for you to create and manage your chatbots.
+    The term 'Experiment' will be phased out as we fully adopt 'Chatbots' instead. Bot building will shift from the current 'form-based' method to primarily using the pipeline approach. All existing experiments will continue to work without disruption during this rollout.
 
-    - **Simplified Workflow**: Pipelines introduces a cleaner, more intuitive interface for building chatbots
-    - **Streamlined Bot Building**: We're transitioning from the 'form-based' approach to make Pipelines the primary (and eventually only) method for bot building
-    - **Seamless Transition**: All existing experiments will continue to work without disruption during this rollout
-    - **Full Support Available**: The Dimagi team is ready to provide help and support as you explore this new feature
+    Some key improvements include:
+    - **Simplified Workflow**: Chatbots introduces a cleaner, more intuitive interface for building chatbots
+    - **Streamlined Bot Building**: We're transitioning from the 'form-based' approach to make pipelines the primary (and eventually only) method for bot building
+    - **Enhanced Features**: The new system allows building more bots with greater flexibility and complexity.
+    - **Enhanced Features**: Chatbots includes features that are not availble to legacy 'Experiments' including:
+        - LLM tools such as 'web search', 'code interpreter', and 'file search'
 
-    We look forward to seeing what you create with Pipelines!
+
+## What is a Chatbot?
+A chatbot is a program that simulates conversation with people. It can use simple rules or advanced AI to understand and respond to messages. 
+
+Within the context of Open Chat Studio, a chatbot is a specific configuration of a language model (LLM) that is designed to interact with users conversationally. It can be customized to perform various tasks, such as answering questions, providing information, or assisting with specific workflows.
+
+The specific way that a chatbot is configured with Open Chat Studio is through the use of a [**Pipeline**](../pipelines/index.md). You can think of a pipeline as a flowchart that starts with user input on one end and ends with the chatbot’s response at the other. Each message sent to the bot follows a specific path through the pipeline to generate the final output. 
+
+This approach can be useful if you want to build a complex bot that performs different tasks depending on the user’s request. Generally, trying to make a single bot prompt do multiple functions doesn’t work well, so it is better to create multiple prompts for each task and then combine them using a Pipeline. 
 
 
-### Pipeline
-[Pipelines](../pipelines/index.md) lets you build more advanced bots by defining a graph—a network of connected nodes representing different steps in a workflow. You can think of this graph as a flowchart that starts with user input and ends with the bot’s response. Each message sent to the bot follows a specific path through the graph to generate the final output.
+## What is a Pipeline?
+As described above, a pipeline is a flowchart-like structure that defines how a chatbot processes user input and generates responses. It consists of a series of connected nodes, each representing a specific step in the workflow. Each node can perform a specific function, such as processing user input, generating responses, or integrating with external systems.
 
-This approach is especially useful when you want your bot to handle different types of tasks based on the user’s request. Instead of forcing a single prompt to do everything (which can lead to more testing and building time), it’s better to create separate prompts for each function and link them together using a Pipeline. This concept is similar to the Multi-bot setup but offers greater flexibility and complexity.
+The simplest pipeline is a single node that takes user input and generates a response. More complex pipelines can include multiple nodes that work together to create a more sophisticated interaction.
+
+You can read more about pipelines in the [Pipelines documentation](../pipelines/index.md).

--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -6,7 +6,7 @@
 A collection in OCS refers to a collection of files. There are two types of collections:
 
 - [Media collection](./media.md)
-- [Indexed Collection (for RAG applications)](./indexes.md)
+- [Indexed Collection (for RAG applications)](./indexed.md)
 
 
 ## Adding a collection to a bot
@@ -38,5 +38,5 @@ Channels that support sending multimedia files will receive each attachment as a
 * WhatsApp (Twilio Provider) - Consult the [Twilio docs][twilio_docs] for supported file types.
 
 
-[llm_node]: ./pipelines/nodes.md
+[llm_node]: ../pipelines/nodes.md
 [twilio_docs]: https://www.twilio.com/docs/whatsapp/guidance-whatsapp-media-messages

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -28,7 +28,7 @@ When you create a collection and upload files to it, you'll be prompted to add a
 
 Additionally, OCS automatically provides the bot with a tool that enables it to attach files to its responses.
 
-The location in the prompt where these summaries are included is defined by the [{media} prompt variable](./prompt_variables.md).
+The location in the prompt where these summaries are included is defined by the [{media} prompt variable](../prompt_variables.md).
 
 Here’s an example of how file details appear in the system prompt:
 ```

--- a/docs/concepts/experiment/index.md
+++ b/docs/concepts/experiment/index.md
@@ -6,7 +6,7 @@ An Experiment links all the configuration and data for a chatbot including user 
 
 !!! warning "Deprecation Warnig"
 
-    The term will be phased out as we fully adopt 'Chatbots' instead. Bot creation will shift from the current 'form-based' method to primarily using the pipeline approach. All existing experiments will be smoothly migrated with adequate notice, and users can contact the Dimagi team for assistance during this transition.
+    The term will be phased out as we fully adopt 'Chatbots' instead. Bot building will shift from the current 'form-based' method to primarily using the pipeline approach. All existing experiments will be smoothly migrated with adequate notice, and users can contact the Dimagi team for assistance during this transition.
 
 ## Experiment Types
 

--- a/docs/concepts/experiment/index.md
+++ b/docs/concepts/experiment/index.md
@@ -1,9 +1,12 @@
 # Experiments
 
-An 'Experiment' is the current name used in Open Chat Studio to refer to a 'chatbot'. The name may change in the
-future.
+An 'Experiment' is the current name used in Open Chat Studio to refer to a 'chatbot'. This will soon be a legacy term as we transition fully to the term 'Chatbots.'
 
 An Experiment links all the configuration and data for a chatbot including user sessions, data, actions etc.
+
+!!! warning "Deprecation Warnig"
+
+    The term will be phased out as we fully adopt 'Chatbots' instead. Bot creation will shift from the current 'form-based' method to primarily using the pipeline approach. All existing experiments will be smoothly migrated with adequate notice, and users can contact the Dimagi team for assistance during this transition.
 
 ## Experiment Types
 
@@ -29,7 +32,7 @@ This allows the bot to write and execute code to accomplish tasks.
 For more information see the [OpenAI docs][5].
 
 #### File Search
-!!! warning 
+!!! warning
 
     The functionality described here is planned to be replaced by [Indexed Collections][indexed-collections] in the future. It’s recommended to start using Indexed Collections instead to ensure forward compatibility.
 

--- a/docs/concepts/experiment/index.md
+++ b/docs/concepts/experiment/index.md
@@ -6,7 +6,7 @@ An Experiment links all the configuration and data for a chatbot including user 
 
 !!! warning "Deprecation Warnig"
 
-    The term will be phased out as we fully adopt 'Chatbots' instead. Bot building will shift from the current 'form-based' method to primarily using the pipeline approach. All existing experiments will be smoothly migrated with adequate notice, and users can contact the Dimagi team for assistance during this transition.
+    The term will be phased out as we fully adopt 'Chatbots' instead. Bot building will shift from the current 'form-based' method to primarily using the pipeline approach. All existing experiments will be smoothly migrated with adequate notice, and users can contact the Dimagi team for assistance during this transition with any questions.
 
 ## Experiment Types
 

--- a/docs/concepts/experiment/index.md
+++ b/docs/concepts/experiment/index.md
@@ -4,7 +4,7 @@ An 'Experiment' is the current name used in Open Chat Studio to refer to a 'chat
 
 An Experiment links all the configuration and data for a chatbot including user sessions, data, actions etc.
 
-!!! warning "Deprecation Warnig"
+!!! warning "Deprecation Warning"
 
     The term will be phased out as we fully adopt 'Chatbots' instead. Bot building will shift from the current 'form-based' method to primarily using the pipeline approach. All existing experiments will be smoothly migrated with adequate notice, and users can contact the Dimagi team for assistance during this transition with any questions.
 

--- a/docs/concepts/experiment/index.md
+++ b/docs/concepts/experiment/index.md
@@ -1,6 +1,6 @@
 # Experiments
 
-An 'Experiment' is the current name used in Open Chat Studio to refer to a 'chatbot'. This will soon be a legacy term as we transition fully to the term 'Chatbots.'
+An 'Experiment' is the current name used in Open Chat Studio to refer to a 'chatbot'. This will soon be a legacy term as we transition fully to the term ['Chatbots'](../chatbots/index.md).
 
 An Experiment links all the configuration and data for a chatbot including user sessions, data, actions etc.
 

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -4,7 +4,7 @@ A pipeline is a way to build a bot by combining one or more steps together.
 
 !!! info "Pipelines are the future"
 
-    Pipelines are currently becoming the default way to build bots in Open Chat Studio. They are a superset of existing functionality, enabling complex safety layers, routing and conditionals. The transition is now underway, and we're providing communication as we begin phasing out other bot building approaches. The Dimagi team is available for support during this transition.
+    Pipelines are currently becoming the default way to build bots in Open Chat Studio. They are a superset of existing functionality, enabling complex safety layers, routing and conditionals. The transition is now underway, and we're providing communication as we begin phasing out other bot building approaches. The Dimagi team is available for support during this transition with any questions.
 
 Here is an example of a very simple pipeline that uses an LLM to respond to the users input. This pipeline has a
 single step that uses the LLM to generate a response.

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -4,7 +4,7 @@ A pipeline is a way to build a bot by combining one or more steps together.
 
 !!! info "Pipelines are the future"
 
-    Pipelines are currently becoming the default way to build bots in Open Chat Studio. They are a superset of existing functionality, enabling complex safety layers, routing and conditionals. The transition is now underway, and we're providing communication as we begin phasing out other bot building approaches. The Dimagi team is available for support during this transition with any questions.
+    Pipelines are currently becoming the default way to build bots in Open Chat Studio. They are a superset of existing functionality, enabling complex safety layers, routing and conditionals. The transition is now underway, and we're providing communication as we begin phasing out other bot building approaches.
 
 Here is an example of a very simple pipeline that uses an LLM to respond to the users input. This pipeline has a
 single step that uses the LLM to generate a response.

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -1,12 +1,12 @@
 # Pipelines
 
-A pipeline is a way to build a bot by combining one or more steps together. 
+A pipeline is a way to build a bot by combining one or more steps together.
 
 !!! info "Pipelines are the future"
 
-    In future, pipelines will be the default way to build bots in Open Chat Studio. They are a superset of existing functionality, enabling complex safety layers, routing and conditionals. There will be ample communication before we deprecate other bot building approaches. 
+    Pipelines are currently becoming the default way to build bots in Open Chat Studio. They are a superset of existing functionality, enabling complex safety layers, routing and conditionals. The transition is now underway, and we're providing communication as we begin phasing out other bot building approaches. The Dimagi team is available for support during this transition.
 
-Here is an example of a very simple pipeline that uses an LLM to respond to the users input. This pipeline has a 
+Here is an example of a very simple pipeline that uses an LLM to respond to the users input. This pipeline has a
 single step that uses the LLM to generate a response.
 
 <figure markdown="span">
@@ -50,5 +50,5 @@ graph TB
   Update participant data with the score`");
   Gen --> C@{ shape: stadium, label: "Output" };
   Rp --> C;
-  Score --> C;  
+  Score --> C;
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,8 @@ nav:
       - how-to/embed.md
   - Concepts:
       - concepts/index.md
+      - Chatbots:
+        - concepts/chatbots/index.md
       - Experiments:
         - concepts/experiment/index.md
         - concepts/sessions.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ plugins:
     default_handler: python
     handlers:
       python:
-        options:
+        options.extra:
           paths: [src]
           heading_level: 3
           show_root_full_path: false
@@ -85,9 +85,9 @@ nav:
       - Chatbots:
         - concepts/chatbots/index.md
       - Experiments:
+        - concepts/llm.md
         - concepts/experiment/index.md
         - concepts/sessions.md
-        - concepts/llm.md
         - concepts/participant_data.md
         - concepts/prompt_variables.md
         - concepts/source_material.md


### PR DESCRIPTION
resolves [#1609](https://github.com/dimagi/open-chat-studio/issues/1609)

Goal of these docs updates are to notify users of upcoming transitions. Banners on the site (located in Pipelines and Experiment homepages) will link to the `chatbots/index.md` page