### PR TITLE
Improve provider configuration documentation

### DIFF
--- a/docs/how-to/configure_providers.md
+++ b/docs/how-to/configure_providers.md
@@ -25,17 +25,17 @@ If your provider doesn't have a pre-configured model you want to use, you can ad
 
 ### Model Naming Conventions
 
-**Important**: Model names must match the exact format used by the provider's API. Use lowercase with hyphens where applicable.
+**Important**: Model names must match the exact format used by the provider's API. Use lowercase with hyphens as specified by the provider.
 
 #### OpenAI Models
 For OpenAI models, use the exact model names from their API documentation. Examples:
-- `gpt-4o` (not "GPT-4o" or "gpt4o")
+- `gpt-4o` (not `GPT-4o` or `gpt4o`)
 - `gpt-5-nano-2025-08-07` (for specific snapshots)
 
 Find current model names at: https://platform.openai.com/docs/models (check the "snapshots" section for each model)
 
 #### Anthropic Models
-For Anthropic (Claude) models, use the names from the "Claude API" column. Examples:
+For Anthropic (Claude) models, use the names from the "Claude API" column in their documentation. Examples:
 - `claude-3-5-sonnet-20241022`
 - `claude-3-haiku-20240307`
 

--- a/docs/how-to/configure_providers.md
+++ b/docs/how-to/configure_providers.md
@@ -1,2 +1,56 @@
 # Configure Providers
-Providers are configured in your team settings. Before configuring a provider, ensure that you have an active account at the provider and access to the necessary integration credentials.
+
+Providers are configured in your team settings under "LLM and Embedding Model Service Providers". Before configuring a provider, ensure that you have an active account at the provider and access to the necessary integration credentials.
+
+## Prerequisites
+
+**API Key Required**: You cannot create a provider without a valid API key. The API key is used for authentication between Open Chat Studio and the provider. You must:
+
+1. Have an active account with the provider (OpenAI, Anthropic, Google, etc.)
+2. Generate an API key from your provider account
+3. Have access to the specific models you want to use
+
+## Adding a New Provider
+
+1. Go to your team settings
+2. Navigate to "LLM and Embedding Model Service Providers"
+3. Click "Add Provider"
+4. Select your provider from the dropdown
+5. Enter your API key
+6. Save the configuration
+
+## Adding Custom Models
+
+If your provider doesn't have a pre-configured model you want to use, you can add it under the "Custom LLM Models" section.
+
+### Model Naming Conventions
+
+**Important**: Model names must match the exact format used by the provider's API. Use lowercase with hyphens where applicable.
+
+#### OpenAI Models
+For OpenAI models, use the exact model names from their API documentation. Examples:
+- `gpt-4o` (not "GPT-4o" or "gpt4o")
+- `gpt-5-nano-2025-08-07` (for specific snapshots)
+
+Find current model names at: https://platform.openai.com/docs/models (check the "snapshots" section for each model)
+
+#### Anthropic Models
+For Anthropic (Claude) models, use the names from the "Claude API" column. Examples:
+- `claude-3-5-sonnet-20241022`
+- `claude-3-haiku-20240307`
+
+Find current model names at: https://docs.claude.com/en/docs/about-claude/models/overview
+
+#### Google Models
+For Google (Gemini) models, use the names from the "Model Variant" column. Examples:
+- `gemini-2.5-flash-exp`
+- `gemini-1.5-pro`
+
+Find current model names at: https://ai.google.dev/gemini-api/docs/models
+
+## Testing Your Configuration
+
+After adding a provider and models, it's recommended to:
+1. Create a test bot
+2. Configure it to use your new provider/model
+3. Send a test message to verify everything works correctly


### PR DESCRIPTION
## Summary
- Add clear prerequisites section explaining API key requirement  
- Include step-by-step instructions for adding providers and custom models
- Add model naming conventions with examples for OpenAI, Anthropic, and Google
- Include links to official documentation for finding correct model names
- Add testing recommendations for new configurations

## Context
Based on user feedback from a Slack conversation where users were confused about:
- Whether API keys are required when creating providers
- Correct format for model names (especially for GPT-5 and Claude models)
- Where to find the correct model naming conventions

## Test plan
- [x] Review documentation for clarity and completeness
- [ ] Have users test the updated instructions
- [ ] Verify all external links work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)