### PR TITLE
Fix changelog workflow failure with quoted PR bodies

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -136,18 +136,28 @@ jobs:
         run: |
           # Export environment variables for template substitution
           export PR_NUMBER="${{ steps.set_vars.outputs.pr_number }}"
-          export PR_TITLE="${{ steps.set_vars.outputs.pr_title }}"
           export PR_URL="${{ steps.set_vars.outputs.pr_url }}"
           export PR_AUTHOR="${{ steps.set_vars.outputs.pr_author }}"
           export PR_MERGED_AT="${{ steps.set_vars.outputs.pr_merged_at }}"
-          export PR_LABELS="${{ steps.set_vars.outputs.pr_labels }}"
           export IS_WIDGET_CHANGE="${{ steps.set_vars.outputs.is_widget_change }}"
           export BASE_BRANCH="${{ steps.set_vars.outputs.base_branch }}"
           export WIDGET_CHANGELOG="${{ env.WIDGET_CHANGELOG }}"
           export MAIN_CHANGELOG="${{ env.MAIN_CHANGELOG }}"
           export WIDGET_PATH_PREFIX="${{ env.WIDGET_PATH_PREFIX }}"
 
-          # Use heredoc for PR_BODY to safely handle quotes and special characters
+          # Use heredoc for variables that may contain quotes and special characters
+          PR_TITLE=$(cat <<'EOF'
+          ${{ steps.set_vars.outputs.pr_title }}
+          EOF
+          )
+          export PR_TITLE
+
+          PR_LABELS=$(cat <<'EOF'
+          ${{ steps.set_vars.outputs.pr_labels }}
+          EOF
+          )
+          export PR_LABELS
+
           PR_BODY=$(cat <<'EOF'
           ${{ steps.set_vars.outputs.pr_body }}
           EOF
@@ -235,24 +245,33 @@ jobs:
             CHANGELOG_DESC="Main changelog (\`${{ env.MAIN_CHANGELOG }}\`)"
           fi
 
+          # Store pr_title safely for use in PR body
+          SOURCE_PR_TITLE=$(cat <<'EOF'
+          ${{ steps.set_vars.outputs.pr_title }}
+          EOF
+          )
+
           echo "Creating pull request..."
           gh pr create \
             --title "$PR_TITLE" \
-            --body "## Summary
-          $CHANGES_DESC based on merged PR in open-chat-studio.
+            --body "$(cat <<EOF
+## Summary
+$CHANGES_DESC based on merged PR in open-chat-studio.
 
-          **Source PR:** ${{ steps.set_vars.outputs.pr_url }}
-          **PR Title:** ${{ steps.set_vars.outputs.pr_title }}
-          **Author:** @${{ steps.set_vars.outputs.pr_author }}
-          **Base Branch:** \`${{ steps.set_vars.outputs.base_branch }}\`
-          **Widget Change:** ${{ steps.set_vars.outputs.is_widget_change == 'true' && '✅ Yes' || '❌ No' }}
+**Source PR:** ${{ steps.set_vars.outputs.pr_url }}
+**PR Title:** $SOURCE_PR_TITLE
+**Author:** @${{ steps.set_vars.outputs.pr_author }}
+**Base Branch:** \`${{ steps.set_vars.outputs.base_branch }}\`
+**Widget Change:** ${{ steps.set_vars.outputs.is_widget_change == 'true' && '✅ Yes' || '❌ No' }}
 
-          ### Changes Made
-          - Changelog ($CHANGELOG_DESC): ${{ steps.check_changes.outputs.changelog_changed == '1' && '✅ Updated' || '⏭️ Skipped' }}
-          - Documentation: ${{ steps.check_changes.outputs.docs_changed != '0' && '✅ Updated' || '⏭️ No updates needed' }}
+### Changes Made
+- Changelog ($CHANGELOG_DESC): ${{ steps.check_changes.outputs.changelog_changed == '1' && '✅ Updated' || '⏭️ Skipped' }}
+- Documentation: ${{ steps.check_changes.outputs.docs_changed != '0' && '✅ Updated' || '⏭️ No updates needed' }}
 
-          ---
-          🤖 This PR was automatically generated using Claude to analyze the source PR and update the changelog and documentation accordingly." \
+---
+🤖 This PR was automatically generated using Claude to analyze the source PR and update the changelog and documentation accordingly.
+EOF
+)" \
             --label "automated" \
             --assignee "${{ steps.set_vars.outputs.pr_author }}" \
             --base "${{ steps.set_vars.outputs.base_branch }}" \
@@ -263,12 +282,18 @@ jobs:
       - name: Generate workflow summary
         if: always()
         run: |
+          # Store pr_title safely
+          SUMMARY_PR_TITLE=$(cat <<'EOF'
+          ${{ steps.set_vars.outputs.pr_title }}
+          EOF
+          )
+
           echo "## Changelog Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| **PR Number** | #${{ steps.set_vars.outputs.pr_number }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| **PR Title** | ${{ steps.set_vars.outputs.pr_title }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **PR Title** | $SUMMARY_PR_TITLE |" >> $GITHUB_STEP_SUMMARY
           echo "| **Base Branch** | \`${{ steps.set_vars.outputs.base_branch }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **Widget Change** | ${{ steps.set_vars.outputs.is_widget_change == 'true' && '✅ Yes' || '❌ No' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| **Changes Made** | ${{ steps.check_changes.outputs.has_changes == 'true' && '✅ Yes' || '❌ No' }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes a bug in the changelog update workflow where it would fail if the PR body contained quotes or other special characters.

## Problem

The workflow was using direct string interpolation to set the PR_BODY environment variable which would cause shell syntax errors when the PR body contained quotes.

## Solution

Changed to use a heredoc for safely setting the PR_BODY variable. The heredoc approach with single-quoted EOF ensures that quotes and special characters are preserved safely without shell expansion.