### PR TITLE
docs: add human annotations documentation

### DIFF
--- a/docs/concepts/annotations/annotating.md
+++ b/docs/concepts/annotations/annotating.md
@@ -1,0 +1,75 @@
+# Annotating
+
+This page covers the reviewer workflow — how to work through an annotation queue, submit annotations, skip items, and flag items for follow-up.
+
+## Accessing Your Queues
+
+Navigate to **Annotation Queues** in the sidebar. You will see all queues you are assigned to (or all team queues, if you have queue management permissions).
+
+!!! note "Annotation Reviewer role"
+    If you have the **Annotation Reviewer** role, you will only see queues you are directly assigned to, and the navigation will be simplified to show only annotation-related pages.
+
+## Starting Annotation
+
+From the queue detail page, click **Start Annotating**. This begins a sequential review session — items are presented one at a time, oldest first.
+
+The annotation UI has two panels:
+
+- **Left panel** — the item content (chat history, participant data, session state)
+- **Right panel** — the annotation form with the queue's schema fields
+
+For session items, the left panel shows:
+
+- Full conversation history with role indicators (human/assistant), message content, and timestamps
+- **Participant Data** tab — any data stored against the participant
+- **Session State** tab — the session's current state variables
+
+## Submitting an Annotation
+
+Fill in the annotation form fields and click **Submit**. Each reviewer can submit only one annotation per item — you cannot edit a submitted annotation.
+
+After submission, the next item is loaded automatically.
+
+!!! tip "Progress indicator"
+    The annotation page shows your personal progress (items you've reviewed vs. total items in the queue).
+
+## Skipping an Item
+
+If you want to come back to an item later, click **Skip**. The item will remain in the queue and you'll be shown the next one. Skipped items will appear again when you've gone through all other available items.
+
+## Flagging an Item
+
+If an item has an issue that prevents annotation — for example, missing content, a corrupted session, or content that needs admin review — use **Flag** and provide a reason.
+
+| Aspect | Detail |
+|--------|--------|
+| **Effect** | Item status changes to **Flagged** |
+| **Reason** | Required — explain why you flagged it |
+| **History** | Flag reasons are recorded with the reviewer's name and timestamp (append-only) |
+| **Unflagging** | Queue managers can unflag an item to return it to the review workflow |
+
+!!! note
+    Flagged items are excluded from the annotation workflow — they won't appear in the normal annotation sequence until unflagged by a manager.
+
+## Item Status Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending
+    Pending --> InProgress : First annotation submitted
+    InProgress --> Completed : Required reviews reached
+    Pending --> Flagged : Reviewer flags item
+    InProgress --> Flagged : Reviewer flags item
+    Flagged --> Pending : Manager unflags
+```
+
+| Status | Meaning |
+|--------|---------|
+| **Pending** | No annotations yet |
+| **In Progress** | At least one annotation submitted, but not yet at the required count |
+| **Completed** | Required number of reviews have been submitted |
+| **Flagged** | Marked for follow-up; excluded from annotation workflow |
+
+## Read-Only View
+
+If you open an item that you've already annotated, or if you don't have annotation permissions, the item is shown in a **read-only view** — you can see the content and any existing annotations, but cannot submit a new one.

--- a/docs/concepts/annotations/index.md
+++ b/docs/concepts/annotations/index.md
@@ -1,0 +1,57 @@
+# Annotations
+
+**Annotations** is a human review system for labeling and evaluating experiment sessions and messages. It enables teams to systematically collect structured feedback from reviewers — useful for data quality assessment, content moderation, chatbot evaluation, and training dataset creation.
+
+## Overview
+
+The annotations system is built around **queues** — organized collections of items that reviewers work through sequentially. Each queue defines a custom set of fields (the schema) that reviewers fill in for every item.
+
+```mermaid
+flowchart LR
+    schema([Annotation Schema]) --> queue([Annotation Queue])
+    sessions([Sessions / Messages]) --> queue
+    queue --> reviewer1([Reviewer])
+    queue --> reviewer2([Reviewer])
+    reviewer1 --> annotation([Annotation])
+    reviewer2 --> annotation
+    annotation --> aggregates([Aggregate Scores])
+```
+
+### Key Components
+
+**[Annotation Queue](queues.md)**
+: The central object. Contains items to be reviewed, defines the annotation schema, manages assignees, and tracks progress.
+
+**Annotation Schema**
+: The set of fields reviewers fill in. Defined per queue. Supports integer, float, string, and choice (enum) field types.
+
+**Annotation Items**
+: Individual sessions or messages added to a queue. Each item moves through a lifecycle: Pending → In Progress → Completed (or Flagged).
+
+**Annotations**
+: A single reviewer's submitted responses for one item. Each reviewer can annotate each item only once.
+
+## Use Cases
+
+- **Quality assurance** — have reviewers rate conversation quality on a defined scale
+- **Content moderation** — flag problematic sessions and categorize issues
+- **Chatbot evaluation** — collect human judgments alongside automated [evaluations](../evaluations/index.md)
+- **Dataset labeling** — annotate sessions for downstream model training or fine-tuning
+- **Inter-rater reliability** — configure multiple reviews per item to measure reviewer agreement
+
+## Roles
+
+| Role | Capabilities |
+|------|-------------|
+| Team Admin / Member (with queue permissions) | Create and manage queues, add sessions, export results, manage assignees, view aggregates |
+| **Annotation Reviewer** | View and annotate queues they are assigned to only. Cannot manage queues, export, or access other app areas. |
+
+!!! note "Annotation Reviewer role"
+    The **Annotation Reviewer** role is designed for external annotators or team members who should only have access to their assigned annotation work — they won't see other parts of the application.
+
+## Getting Started
+
+1. [Create an annotation queue](queues.md#creating-a-queue) with a schema and assignees
+2. [Add sessions](queues.md#adding-items) to the queue
+3. Assignees [work through items](annotating.md) and submit annotations
+4. Review progress and [export results](queues.md#exporting-results)

--- a/docs/concepts/annotations/index.md
+++ b/docs/concepts/annotations/index.md
@@ -26,7 +26,7 @@ flowchart LR
 : The set of fields reviewers fill in. Defined per queue. Supports integer, float, string, and choice (enum) field types.
 
 **Annotation Items**
-: Individual sessions or messages added to a queue. Each item moves through a lifecycle: Pending → In Progress → Completed (or Flagged).
+: Individual sessions added to a queue. Each item moves through a lifecycle: Pending → In Progress → Completed (or Flagged).
 
 **Annotations**
 : A single reviewer's submitted responses for one item. Each reviewer can annotate each item only once.

--- a/docs/concepts/annotations/queues.md
+++ b/docs/concepts/annotations/queues.md
@@ -1,0 +1,115 @@
+# Annotation Queues
+
+An **Annotation Queue** is the central object in the annotations system. It defines what to review (the items), how to review it (the schema), who reviews it (the assignees), and how many reviews each item needs.
+
+## Annotation Schema
+
+Before creating a queue, you need to decide what fields reviewers will fill in. These fields are defined as part of the queue's **schema**.
+
+### Field Types
+
+| Type | Description | Options |
+|------|-------------|---------|
+| **integer** | Whole number input | Optional min/max constraints |
+| **float** | Decimal number input | Optional min/max constraints |
+| **string** | Free-text input | Optional max length |
+| **choices** | Dropdown with predefined options | List of allowed values (required) |
+
+Each field has a **name** and an optional **description** to guide reviewers.
+
+**Example schema:**
+
+| Field Name | Type | Description |
+|------------|------|-------------|
+| `helpfulness` | integer (1–5) | How helpful was the assistant's response? |
+| `tone` | choices (professional, neutral, inappropriate) | Describe the tone of the conversation |
+| `notes` | string | Any additional observations |
+
+## Creating a Queue
+
+Navigate to **Annotation Queues** in the left sidebar and click **New Queue**.
+
+| Field | Description |
+|-------|-------------|
+| **Name** | Unique name for this queue within your team |
+| **Description** | Optional context for reviewers |
+| **Schema** | Add one or more annotation fields (see above) |
+| **Assignees** | Team members who will review items in this queue |
+| **Reviews required** | Number of independent reviews needed per item (1–10, default: 1) |
+
+!!! tip "Multiple reviews"
+    Setting **Reviews required** to more than 1 is useful when you want multiple reviewers to independently annotate the same item — for example, to measure inter-rater agreement or to get a consensus rating. An item is marked **Completed** only when it has received the required number of reviews.
+
+### Queue Status
+
+| Status | Meaning |
+|--------|---------|
+| **Active** | Open for annotation |
+| **Paused** | Temporarily closed; reviewers cannot submit new annotations |
+| **Completed** | All items have been reviewed |
+| **Archived** | Queue is closed and no longer active |
+
+## Adding Items
+
+Items can be added to a queue in three ways.
+
+### 1. Session Selector
+
+From the queue detail page, click **Add Sessions**. This opens a filterable table of experiment sessions. You can then choose how many sessions to add:
+
+| Mode | Description |
+|------|-------------|
+| **Selected only** (default) | Add only the sessions you've checked |
+| **All matching filters** | Add every session matching the current filter criteria |
+| **Sample** | Add a random percentage of sessions matching the current filters |
+
+!!! note
+    A confirmation prompt is shown for bulk operations (all matching, or large samples).
+
+Sessions that are already in the queue are excluded from the selector.
+
+### 2. Import from Evaluations Dataset
+
+Click **Import from Dataset** on the queue detail page to add sessions from an existing [evaluations dataset](../evaluations/dataset.md). This is useful when you want to annotate the same set of sessions you used for automated evaluations.
+
+### 3. From a Session Detail Page
+
+On any session detail page, use the **Add to Queue** button to add that session directly to one or more annotation queues.
+
+## Monitoring Progress
+
+The queue detail page shows a progress summary:
+
+- **Total items** in the queue
+- **Completed** items (reached required number of reviews)
+- **Flagged** items
+- **Overall review progress** as a percentage (reviews done / reviews needed)
+
+## Aggregate Scores
+
+After annotations are submitted, **aggregate scores** are automatically computed and displayed on the queue detail page.
+
+| Field Type | Aggregates Shown |
+|------------|-----------------|
+| Numeric (integer, float) | Mean, median, min, max, standard deviation |
+| Categorical (choices) | Mode, distribution percentages per option |
+
+Aggregates are recomputed after each annotation submission, so you always see up-to-date stats.
+
+## Exporting Results
+
+From the queue detail page (requires queue management permissions), you can export all submitted annotations:
+
+| Format | Description |
+|--------|-------------|
+| **CSV** | Spreadsheet-friendly, one row per annotation |
+| **JSONL** | One JSON object per line, suitable for programmatic processing |
+
+The export includes the item details, reviewer, and all annotation field values.
+
+## Managing Assignees
+
+Use **Manage Assignees** on the queue detail page to add or remove reviewers. Assignees receive access to the queue and can see it in their annotation queue list.
+
+!!! note
+    If a queue has no assignees, any team member with the annotation permission can annotate items in it. Once assignees are added, only they can submit annotations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,10 @@ nav:
         - concepts/evaluations/index.md
         - concepts/evaluations/dataset.md
         - concepts/evaluations/evaluators.md
+      - Annotations:
+        - concepts/annotations/index.md
+        - concepts/annotations/queues.md
+        - Annotating: concepts/annotations/annotating.md
       - API:
         - api/index.md
         - api/getting_started_with_oauth.md


### PR DESCRIPTION
Adds user documentation for the Human Annotations feature.

## Changes

- New  section with 3 pages:
  - **index.md** — Overview, key components, use cases, roles
  - **queues.md** — Creating queues, schema field types, adding items (session selector modes, dataset import, session detail button), progress tracking, aggregate scores, export
  - **annotating.md** — Reviewer workflow: accessing queues, the annotation UI, submitting, skipping, flagging, item status lifecycle

- Updated  nav to include the new Annotations section under Concepts (after Evaluations)

Closes dimagi/open-chat-studio#3137