### PR TITLE
fix: replace attach_file_from_response with add_file_attachment

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -110,7 +110,7 @@ hide:
 * **NEW** Notifications system now maintains event history, allowing users to view past notifications and events. Users can also mute notifications per-event or enable "Do Not Disturb" mode to mute all notifications.
 
 ## Feb 11, 2026
-* **NEW** Python nodes can now attach files fetched via HTTP to AI response messages using the new `attach_file_from_response()` helper and `response_bytes` field on HTTP responses.
+* **NEW** Python nodes can now attach files fetched via HTTP to AI response messages using the new `add_file_attachment()` helper and `response_bytes` field on HTTP responses.
 * **NEW** Added notification events that alert you when something important or noteworthy happens in your system, including failures across custom actions (health checks, API failures), chat operations (pipeline execution, LLM errors, tool failures), media handling (audio synthesis/transcription), and message delivery (platform-specific failures). This feature is currently in beta and can be requested for your team.
 
 ## Feb 10, 2026

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -110,7 +110,7 @@ hide:
 * **NEW** Notifications system now maintains event history, allowing users to view past notifications and events. Users can also mute notifications per-event or enable "Do Not Disturb" mode to mute all notifications.
 
 ## Feb 11, 2026
-* **NEW** Python nodes can now attach files fetched via HTTP to AI response messages using the new `add_file_attachment()` helper and `response_bytes` field on HTTP responses.
+* **NEW** Python nodes can now attach files fetched via HTTP to AI response messages using the `add_file_attachment()` helper and `response_bytes` field on HTTP responses. Note: originally documented as `attach_file_from_response(response_bytes, filename)`; the correct name and signature is `add_file_attachment(filename, content, content_type=None)`.
 * **NEW** Added notification events that alert you when something important or noteworthy happens in your system, including failures across custom actions (health checks, API failures), chat operations (pipeline execution, LLM errors, tool failures), media handling (audio synthesis/transcription), and message delivery (platform-specific failures). This feature is currently in beta and can be requested for your team.
 
 ## Feb 10, 2026

--- a/docs/tech-hub/external-api-calls/http_client.md
+++ b/docs/tech-hub/external-api-calls/http_client.md
@@ -396,6 +396,16 @@ def main(input, **kwargs) -> str:
 
 The HTTP client can be used in combination with the `add_file_attachment()` helper function to download files from external APIs and attach them to the chat session. This is useful for generating reports, downloading documents, or retrieving images to share with the user.
 
+The optional `content_type` argument lets you specify the MIME type explicitly when it cannot be reliably inferred from the filename (e.g. files with no extension or a generic `.bin` extension):
+
+```python
+add_file_attachment(
+    filename="report",
+    content=response["response_bytes"],
+    content_type="application/pdf"
+)
+```
+
 ### Example 9: Downloading and Attaching a File
 
 ```python
@@ -428,6 +438,7 @@ def main(input, **kwargs) -> str:
     # Parse which charts the user wants
     chart_types = ["sales", "revenue", "customers"]
 
+    attached = 0
     for chart_type in chart_types:
         response = http.get(
             f"https://api.example.com/charts/{chart_type}.png",
@@ -440,8 +451,11 @@ def main(input, **kwargs) -> str:
                 filename=f"{chart_type}_chart.png",
                 content=response["response_bytes"]
             )
+            attached += 1
 
-    return f"I've attached {len(chart_types)} charts for your review."
+    if attached == 0:
+        return "Failed to download any charts."
+    return f"I've attached {attached} chart(s) for your review."
 ```
 
 See the [Python Node utility functions](../python_node.md#python_node.add_file_attachment) documentation for more details on the `add_file_attachment()` function.

--- a/docs/tech-hub/external-api-calls/http_client.md
+++ b/docs/tech-hub/external-api-calls/http_client.md
@@ -394,7 +394,7 @@ def main(input, **kwargs) -> str:
 
 ## Downloading and Attaching Files
 
-The HTTP client can be used in combination with the `attach_file_from_response()` helper function to download files from external APIs and attach them to the chat session. This is useful for generating reports, downloading documents, or retrieving images to share with the user.
+The HTTP client can be used in combination with the `add_file_attachment()` helper function to download files from external APIs and attach them to the chat session. This is useful for generating reports, downloading documents, or retrieving images to share with the user.
 
 ### Example 9: Downloading and Attaching a File
 
@@ -412,9 +412,9 @@ def main(input, **kwargs) -> str:
         return f"Failed to download report: {response['status_code']}"
 
     # Attach the file to the chat session
-    attach_file_from_response(
-        response_bytes=response["response_bytes"],
-        filename="monthly_report.pdf"
+    add_file_attachment(
+        filename="monthly_report.pdf",
+        content=response["response_bytes"]
     )
 
     return "I've attached the monthly report for you to review."
@@ -436,15 +436,15 @@ def main(input, **kwargs) -> str:
         )
 
         if response["is_success"]:
-            attach_file_from_response(
-                response_bytes=response["response_bytes"],
-                filename=f"{chart_type}_chart.png"
+            add_file_attachment(
+                filename=f"{chart_type}_chart.png",
+                content=response["response_bytes"]
             )
 
     return f"I've attached {len(chart_types)} charts for your review."
 ```
 
-See the [Python Node utility functions](../python_node.md#python_node.attach_file_from_response) documentation for more details on the `attach_file_from_response()` function.
+See the [Python Node utility functions](../python_node.md#python_node.add_file_attachment) documentation for more details on the `add_file_attachment()` function.
 
 ## Common Status Codes
 

--- a/docs/tech-hub/python_node.md
+++ b/docs/tech-hub/python_node.md
@@ -62,7 +62,7 @@ The Python node provides a set of utility functions that can be used to interact
 ### ::: python_node.wait_for_next_input
 ### ::: python_node.abort_with_message
 ### ::: python_node.end_session
-### ::: python_node.attach_file_from_response
+### ::: python_node.add_file_attachment
 
 ## Debugging with print()
 

--- a/src/python_node/__init__.py
+++ b/src/python_node/__init__.py
@@ -188,6 +188,20 @@ def add_file_attachment(filename: str, content: bytes, content_type: str | None 
                 return "I've attached the report for you."
 
             return "Failed to download the report."
+
+        def main_explicit_mime(input, **kwargs):
+            # When the filename alone doesn't reliably indicate the MIME type
+            response = http.get("https://api.example.com/export", auth="my-api")
+
+            if response["is_success"]:
+                add_file_attachment(
+                    filename="export",
+                    content=response["response_bytes"],
+                    content_type="application/pdf"
+                )
+                return "Export attached."
+
+            return "Failed to retrieve export."
         ```
 
     See also: [HTTP Client - Downloading and Attaching Files](external-api-calls/http_client.md#downloading-and-attaching-files)

--- a/src/python_node/__init__.py
+++ b/src/python_node/__init__.py
@@ -161,15 +161,17 @@ def wait_for_next_input():
     """
 
 
-def attach_file_from_response(response_bytes: bytes, filename: str) -> None:
-    """Attaches a file downloaded from an HTTP response to the chat session.
+def add_file_attachment(filename: str, content: bytes, content_type: str | None = None) -> None:
+    """Attaches a file to the chat session.
 
-    This function is used in combination with the HTTP client to download files from external APIs
-    and attach them to the assistant's response message. The file will be available for the user to download.
+    This function can be used to attach files (e.g. downloaded via the HTTP client) to the
+    assistant's response message. The file will be available for the user to download.
 
     Args:
-        response_bytes: The raw bytes of the file, typically from the `response_bytes` field of an HTTP response
         filename: The name to give the attached file, including the file extension
+        content: The raw bytes of the file content
+        content_type: Optional MIME type of the file (e.g. `"application/pdf"`, `"image/png"`).
+            If not provided, it will be inferred from the filename.
 
     Example:
         ```python
@@ -179,9 +181,9 @@ def attach_file_from_response(response_bytes: bytes, filename: str) -> None:
 
             if response["is_success"]:
                 # Attach the file to the chat
-                attach_file_from_response(
-                    response_bytes=response["response_bytes"],
-                    filename="report.pdf"
+                add_file_attachment(
+                    filename="report.pdf",
+                    content=response["response_bytes"]
                 )
                 return "I've attached the report for you."
 


### PR DESCRIPTION
## Summary

The docs incorrectly referenced a function called `attach_file_from_response` which does not exist in the codebase.

The correct function signature is:
```python
def add_file_attachment(filename: str, content: bytes, content_type: str | None = None)
```

## Changes

- **`src/python_node/__init__.py`** — Updated function stub, signature, docstring args, and example
- **`docs/tech-hub/python_node.md`** — Updated API reference entry
- **`docs/tech-hub/external-api-calls/http_client.md`** — Updated prose, two code examples, and cross-reference link
- **`docs/changelog.md`** — Updated historical entry

Reported by Simon Kelly.