### PR TITLE
Enhance chatbot and pipeline definitions & pipelines page

### DIFF
--- a/docs/concepts/chatbots/index.md
+++ b/docs/concepts/chatbots/index.md
@@ -1,11 +1,15 @@
 # Chatbots
 
 ## What is a Chatbot?
-A chatbot is a program that simulates conversation with people. It can use simple rules or advanced AI to understand and respond to messages. 
+A chatbot in Open Chat Studio is the bot configuration that users interact with. It defines the conversational experience, while the underlying [pipeline](../pipelines/index.md) controls how messages are processed and responses are generated.
 
-Within the context of Open Chat Studio, a chatbot is a specific configuration of a language model ([LLM](../llm.md)) that is designed to interact with users conversationally. It can be customized to perform various tasks, such as answering questions, providing information, or assisting with specific workflows.
+Chatbots can be connected to one or more channels, use [LLMs](../llm.md) to generate responses, and include supporting logic such as routing, participant data, or custom actions.
 
-Every chatbot in Open Chat Studio is configured using a visual workflow called a [**Pipeline**](../pipelines/index.md). 
+## Creating a Chatbot
+Every chatbot in Open Chat Studio is configured using a visual workflow called a [**Pipeline**](../pipelines/index.md).
+
+Use the resources below to learn how to create a chatbot and how its pipeline works:
 
 - :material-clock-fast:{ .lg .middle } [__Quickstart Guide__](../../tutorials/first_chatbot.md)
-- :octicons-ai-model-24:{ .lg .middle } [__What is an LLM?__](../llm.md)
+- :material-chat-question:{ .lg .middle } [__What is a Pipeline?__](../pipelines/index.md#what-is-a-pipeline)
+- :material-whatsapp:{ .lg .middle } [__Deploying your bot__](../../how-to/deploy_to_different_channels.md)

--- a/docs/concepts/chatbots/index.md
+++ b/docs/concepts/chatbots/index.md
@@ -5,14 +5,5 @@ A chatbot is a program that simulates conversation with people. It can use simpl
 
 Within the context of Open Chat Studio, a chatbot is a specific configuration of a language model (LLM) that is designed to interact with users conversationally. It can be customized to perform various tasks, such as answering questions, providing information, or assisting with specific workflows.
 
-The specific way that a chatbot is configured with Open Chat Studio is through the use of a [**Pipeline**](../pipelines/index.md). You can think of a pipeline as a flowchart that starts with user input on one end and ends with the chatbot’s response at the other. Each message sent to the bot follows a specific path through the pipeline to generate the final output. 
+Every chatbot in Open Chat Studio is configured using a visual workflow called a [**Pipeline**](../pipelines/index.md). The workflow visualization makes it easy to understand how the bot processes each message and generates a response. Pipelines make it easy to build complex bots by breaking the workflow into smaller, focused steps rather than trying to do everything in a single prompt.
 
-This approach can be useful if you want to build a complex bot that performs different tasks depending on the user’s request. Generally, trying to make a single bot prompt do multiple functions doesn’t work well, so it is better to create multiple prompts for each task and then combine them using a Pipeline. 
-
-
-## What is a Pipeline?
-As described above, a pipeline is a flowchart-like structure that defines how a chatbot processes user input and generates responses. It consists of a series of connected nodes, each representing a specific step in the workflow. Each node can perform a specific function, such as processing user input, generating responses, or integrating with external systems.
-
-The simplest pipeline is a single node that takes user input and generates a response. More complex pipelines can include multiple nodes that work together to create a more sophisticated interaction.
-
-You can read more about pipelines in the [Pipelines documentation](../pipelines/index.md).

--- a/docs/concepts/chatbots/index.md
+++ b/docs/concepts/chatbots/index.md
@@ -3,7 +3,9 @@
 ## What is a Chatbot?
 A chatbot is a program that simulates conversation with people. It can use simple rules or advanced AI to understand and respond to messages. 
 
-Within the context of Open Chat Studio, a chatbot is a specific configuration of a language model (LLM) that is designed to interact with users conversationally. It can be customized to perform various tasks, such as answering questions, providing information, or assisting with specific workflows.
+Within the context of Open Chat Studio, a chatbot is a specific configuration of a language model ([LLM](../llm.md)) that is designed to interact with users conversationally. It can be customized to perform various tasks, such as answering questions, providing information, or assisting with specific workflows.
 
-Every chatbot in Open Chat Studio is configured using a visual workflow called a [**Pipeline**](../pipelines/index.md). The workflow visualization makes it easy to understand how the bot processes each message and generates a response. Pipelines make it easy to build complex bots by breaking the workflow into smaller, focused steps rather than trying to do everything in a single prompt.
+Every chatbot in Open Chat Studio is configured using a visual workflow called a [**Pipeline**](../pipelines/index.md). 
 
+- :material-clock-fast:{ .lg .middle } [__Quickstart Guide__](../../tutorials/first_chatbot.md)
+- :octicons-ai-model-24:{ .lg .middle } [__What is an LLM?__](../llm.md)

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -25,7 +25,7 @@ the [How-to guides](../how-to/index.md).
 : The platform through which a chat occurs (e.g., WhatsApp, Telegram, Web, Slack).
 
 [Chatbot](chatbots/index.md)
-: A chatbot links all the configuration and data for a bot, including user sessions, data, actions, and related settings. This was historically called an "Experiment"
+: A chatbot is an AI-powered conversational agent configured in Open Chat Studio to interact with users across one or more channels.
 
 [Consent Forms](consent.md)
 : Forms that provide context to chatbot users on how their data will be used and who to contact regarding any concerns.
@@ -45,11 +45,14 @@ the [How-to guides](../how-to/index.md).
 [Messaging Provider](team/messaging_providers.md)
 : Messaging providers hold the configuration required to send messages to users on a specific channel.
 
+[Node](./pipelines/nodes.md)
+: A single processing step within a chatbot's pipeline workflow.
+
 [Participant Data](participant_data.md)
 : Data that persists across sessions and is tied to the same `User, Channel, Chatbot` scope. It helps retain long-term user preferences and contextual information beyond a single session.
 
 [Pipelines](pipelines/index.md)
-: A pipeline is a way to build a bot by combining one or more steps together.
+: A pipeline is a visual workflow that defines how your chatbot processes a user's message and generates a response.
 
 [Prompt](prompt_variables.md)
 : A prompt is the instructions that are given to the LLM to generate a response. Prompts can include text, source material, and other variables.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -25,7 +25,7 @@ the [How-to guides](../how-to/index.md).
 : The platform through which a chat occurs (e.g., WhatsApp, Telegram, Web, Slack).
 
 [Chatbot](chatbots/index.md)
-: A chatbot is an AI-powered conversational agent configured in Open Chat Studio to interact with users across one or more channels.
+: A chatbot in Open Chat Studio is a bot configuration that interacts with users across one or more channels.
 
 [Consent Forms](consent.md)
 : Forms that provide context to chatbot users on how their data will be used and who to contact regarding any concerns.
@@ -46,13 +46,13 @@ the [How-to guides](../how-to/index.md).
 : Messaging providers hold the configuration required to send messages to users on a specific channel.
 
 [Node](./pipelines/nodes.md)
-: A single processing step within a chatbot's pipeline workflow.
+: A node is a single step in a chatbot's pipeline.
 
 [Participant Data](participant_data.md)
 : Data that persists across sessions and is tied to the same `User, Channel, Chatbot` scope. It helps retain long-term user preferences and contextual information beyond a single session.
 
 [Pipelines](pipelines/index.md)
-: A pipeline is a visual workflow that defines how your chatbot processes a user's message and generates a response.
+: A pipeline is the visual workflow that controls how a chatbot processes input and produces output.
 
 [Prompt](prompt_variables.md)
 : A prompt is the instructions that are given to the LLM to generate a response. Prompts can include text, source material, and other variables.

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -1,33 +1,24 @@
 # Pipelines
 
-A **pipeline** is a visual workflow that defines how your chatbot processes a user's message and generates a response. It is made up of connected **nodes** — each node performs one task, such as calling an AI model, running custom logic, or routing the conversation to a different path. A message enters the pipeline as **input**, passes through one or more nodes, and exits as the chatbot's **output**.
+A **pipeline** is a visual workflow in Open Chat Studio (OCS) that makes it easy to build chatbots that can perform multiple or complex tasks.
 
-!!! info "Pipelines are now the standard way to build bots"
+A chatbot pipeline is made up of connected **nodes** — each node performs one task, such as calling a Large Language Model (LLM), running custom logic, or routing the conversation to a different workflow path. A message enters the pipeline as **input**, passes through one or more nodes, and exits as the chatbot's **output** as a response to the user.
 
-    Pipelines are the default way to build bots in Open Chat Studio. They replace older approaches and support everything from simple single-step responses to complex workflows with branching, parallel steps, and safety layers.
+``` mermaid
+graph LR
+  A@{ shape: stadium, label: "Input" } --> B(Node);
+  B --> C@{ shape: stadium, label: "Output" };
+```
+Every time a user sends a message, the pipeline workflow runs from start to finish and the final output is sent back to the user.
 
 ## A Simple Example
 
-The pipeline below has a single node. The user sends a message, the LLM generates a reply, and that reply is sent back to the user. That's it.
+The OCS screenshot below shows a chatbot that has a single node in its pipeline. The user sends a message, the LLM node generates a reply, and that reply is sent back to the user. That's it.
 
 <figure markdown="span">
   ![A Simple Pipeline](../../assets/images/pipeline-basic.png)
   <figcaption>A simple pipeline</figcaption>
 </figure>
-
-``` mermaid
-graph LR
-  A@{ shape: stadium, label: "Input" } --> B(LLM);
-  B --> C@{ shape: stadium, label: "Output" };
-```
-
-Analyzing this pipeline from left to right:
-
-* the user sends a message to the bot (this is the `input`)
-* the message is then passed to the LLM which generates a response
-* the response is then sent back to the user (this is the `output`)
-
-Every time a user sends a message, the pipeline workflow runs from start to finish and the final output is sent back to the user.
 
 Each step in a pipeline is called a **node**. Pipelines can have as many nodes as your workflow requires. See [Node Types](nodes.md) for a full list of what each node can do.
 
@@ -35,7 +26,7 @@ Each step in a pipeline is called a **node**. Pipelines can have as many nodes a
 
 Open Chat Studio  runs your application in organized steps. Think of it like a well-coordinated team where different parts of your application (pipeline **nodes**) communicate through shared **channels** (pipeline edges / connections).
 
-When a user sends a message, Open Chat Studio processes the pipeline in repeating cycles:
+When a user sends a message, Open Chat Studio processes the chatbot pipeline in repeating cycles:
 
 **Plan** → **Execute** → **Update** → Repeat
 

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -1,38 +1,87 @@
 # Pipelines
 
-A **pipeline** is a visual workflow in Open Chat Studio (OCS) that makes it easy to build chatbots that can perform multiple or complex tasks.
+## What is a Pipeline?
 
-A chatbot pipeline is made up of connected **nodes** — each node performs one task, such as calling a Large Language Model (LLM), running custom logic, or routing the conversation to a different workflow path. A message enters the pipeline as **input**, passes through one or more nodes, and exits as the chatbot's **output** as a response to the user.
+A **pipeline** is a visual workflow in Open Chat Studio that defines how a chatbot processes messages and generates responses. Think of it like a recipe or assembly line — each step in the pipeline does one specific job, and the steps are connected together to create a complete conversation flow.
 
-``` mermaid
-graph LR
-  A@{ shape: stadium, label: "Input" } --> B(Node);
-  B --> C@{ shape: stadium, label: "Output" };
-```
-Every time a user sends a message, the pipeline workflow runs from start to finish and the final output is sent back to the user.
+### In Plain English
+
+Imagine a customer service chatbot:
+
+1. A customer sends a question
+2. The chatbot receives the message (input)
+3. It processes the message through a series of steps (the pipeline)
+4. Finally, it sends back an answer (output)
+
+## What is a Node?
+Each step in the pipeline is called a **node**. A node performs one specific task, such as:
+
+- Calling an AI model to generate a response ([LLM node](nodes.md#llm-node))
+- Running custom logic or code ([Python node](nodes.md#python-node))
+- Making decisions about which way the conversation should go ([Router nodes](nodes.md#routing-nodes))
+- Sending emails or extracting data (specialty nodes)
+
+Pipelines are **visual** — you build them by dragging nodes onto a canvas and connecting them with lines, making it easy to see and understand your chatbot's logic without writing complex code.
+
 
 ## A Simple Example
 
-The OCS screenshot below shows a chatbot that has a single node in its pipeline. The user sends a message, the LLM node generates a reply, and that reply is sent back to the user. That's it.
+Here's the simplest possible chatbot pipeline — it has just **one node**:
 
 <figure markdown="span">
   ![A Simple Pipeline](../../assets/images/pipeline-basic.png)
   <figcaption>A simple pipeline</figcaption>
 </figure>
 
-Each step in a pipeline is called a **node**. Pipelines can have as many nodes as your workflow requires. See [Node Types](nodes.md) for a full list of what each node can do.
+In this simple pipeline:
+
+1. A user sends a message
+2. The [LLM node](nodes.md#llm-node) receives the message and uses AI to generate a response
+3. The response is sent back to the user
+
+That's the complete conversation flow! Every time the user sends a message, the pipeline runs through all its steps (in this case, just one) and returns the output.
+
+## Complex Pipelines
+
+Most real-world chatbots are more complex than a single node. Pipelines become powerful when you combine multiple types of nodes to handle different tasks.
+
+By breaking tasks into separate nodes, you can:
+
+- Keep logic focused and easy to understand
+- Reuse nodes across different parts of your pipeline
+- Test and modify individual steps without affecting the whole pipeline
+- Scale complex workflows without overwhelming a single AI prompt
+
+### Node Types for Complex Pipelines
+
+Here are the main node types you can use to build more sophisticated chatbots:
+
+ - **[LLM Node](nodes.md#llm-node)** — Processes messages using an AI model. Handles natural conversations, answering questions, and generating responses.
+
+ - **[Routing Nodes](nodes.md#routing-nodes)** — Makes decisions about which path the conversation should take based on the message content. Useful for directing different types of questions to different handling logic, or routing based on user intent.
+
+ - **[Python Node](nodes.md#python-node)** — Runs custom code to handle complex logic, fetch data from external systems, process attachments, or manipulate participant data.
+
+ - **[Render Template Node](nodes.md#render-a-template-node)** — Formats responses using templates, allowing you to customize messages with dynamic data.
+
+ - **[Send Email Node](nodes.md#send-an-email-node)** — Sends emails as part of your pipeline, useful for notifications or confirmations.
+
+ - **[Extract Structured Data Node](nodes.md#extract-structured-data-node)** — Pulls specific information from conversations and structures it for downstream processing.
+
+ - **[Update Participant Data Node](nodes.md#update-participant-data-node)** — Saves information about the user for later use in the conversation.
+
 
 ## How a Pipeline Runs
 
-Open Chat Studio  runs your application in organized steps. Think of it like a well-coordinated team where different parts of your application (pipeline **nodes**) communicate through shared **channels** (pipeline edges / connections).
+Open Chat Studio (OCS) executes your pipeline in organized steps, running nodes in parallel when possible. Think of it like a well-coordinated team where different pipeline **nodes** work together, each completing their task and passing results forward.
 
-When a user sends a message, Open Chat Studio processes the chatbot pipeline in repeating cycles:
+When a user sends a message, OCS processes the chatbot pipeline in repeating passes:
 
 **Plan** → **Execute** → **Update** → Repeat
 
-1. **Plan**: Identify which nodes are ready to run. On the first cycle, this is the node connected to the user's input. On later cycles, it is any node whose dependencies have been satisfied.
+1. **Plan**: Identify which nodes are ready to run. On the first pass, this is the node(s) directly connected to the user's input. On later passes, any node whose dependencies have been satisfied is ready.
 
-2. **Execute**: Run all ready nodes at the same time. Each node works independently — it cannot see the results of other nodes running in the same cycle.
+2. **Execute**: Run all ready nodes in parallel. Each node processes independently — it cannot see the results of other nodes running in the same pass.
 
 3. **Update**: Share the results from all nodes so they're available for the next step.
 
@@ -40,10 +89,11 @@ This repeats until all nodes have completed or a maximum step limit is reached.
 
 !!! tip "Running nodes in parallel"
 
-    Because multiple nodes can execute in the same cycle, pipelines naturally support parallel processing. See [Parallel Pipelines](./parallel.md) for details.
+  Because multiple nodes can execute in the same pass, pipelines naturally support parallel processing. See [Parallel Pipelines](./parallel.md) for details.
+
 
 ## Asking the Assistant About a Pipeline
 
 !!! tip "Chat widget context"
 
-    When you are viewing a pipeline in Open Chat Studio, the in-app chat widget automatically receives the pipeline's structure (nodes and connections) and event trigger data as context. This means you can ask the assistant questions about the pipeline you are currently editing — for example, what a particular node does or how the flow is connected. The context updates automatically as you make changes to the pipeline.
+    When you are viewing a pipeline in OCS, the in-app chat widget automatically receives the pipeline's structure (nodes and connections) and event trigger data as context. This means you can ask the assistant questions about the pipeline you are currently editing — for example, what a particular node does or how the flow is connected. The context updates automatically as you make changes to the pipeline.

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -4,15 +4,6 @@
 
 A **pipeline** is a visual workflow in Open Chat Studio that defines how a chatbot processes messages and generates responses. Think of it like a recipe or assembly line — each step in the pipeline does one specific job, and the steps are connected together to create a complete conversation flow.
 
-### In Plain English
-
-Imagine a customer service chatbot:
-
-1. A customer sends a question
-2. The chatbot receives the message (input)
-3. It processes the message through a series of steps (the pipeline)
-4. Finally, it sends back an answer (output)
-
 ## What is a Node?
 Each step in the pipeline is called a **node**. A node performs one specific task, such as:
 
@@ -21,7 +12,7 @@ Each step in the pipeline is called a **node**. A node performs one specific tas
 - Making decisions about which way the conversation should go ([Router nodes](nodes.md#routing-nodes))
 - Sending emails or extracting data (specialty nodes)
 
-Pipelines are **visual** — you build them by dragging nodes onto a canvas and connecting them with lines, making it easy to see and understand your chatbot's logic without writing complex code.
+Pipelines are **visual** — you build them by dragging nodes onto a canvas and connecting them with lines, making chatbot logic easier to understand and maintain without writing complex code.
 
 
 ## A Simple Example
@@ -39,13 +30,13 @@ In this simple pipeline:
 2. The [LLM node](nodes.md#llm-node) receives the message and uses AI to generate a response
 3. The response is sent back to the user
 
-That's the complete conversation flow! Every time the user sends a message, the pipeline runs through all its steps (in this case, just one) and returns the output.
+This is the complete conversation flow for a single-node chatbot.
 
 ## Complex Pipelines
 
 Most real-world chatbots are more complex than a single node. Pipelines become powerful when you combine multiple types of nodes to handle different tasks.
 
-By breaking tasks into separate nodes, you can:
+Breaking work into separate nodes lets you:
 
 - Keep logic focused and easy to understand
 - Reuse nodes across different parts of your pipeline
@@ -54,7 +45,7 @@ By breaking tasks into separate nodes, you can:
 
 ### Node Types for Complex Pipelines
 
-Here are the main node types you can use to build more sophisticated chatbots:
+Common node types include:
 
  - **[LLM Node](nodes.md#llm-node)** — Processes messages using an AI model. Handles natural conversations, answering questions, and generating responses.
 
@@ -73,9 +64,9 @@ Here are the main node types you can use to build more sophisticated chatbots:
 
 ## How a Pipeline Runs
 
-Open Chat Studio (OCS) executes your pipeline in organized steps, running nodes in parallel when possible. Think of it like a well-coordinated team where different pipeline **nodes** work together, each completing their task and passing results forward.
+Open Chat Studio (OCS) executes your pipeline in organized steps, running nodes in parallel when possible.
 
-When a user sends a message, OCS processes the chatbot pipeline in repeating passes:
+When a user sends a message, OCS processes the pipeline in repeating passes:
 
 **Plan** → **Execute** → **Update** → Repeat
 

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -32,7 +32,7 @@ When a user sends a message, Open Chat Studio processes the chatbot pipeline in 
 
 1. **Plan**: Identify which nodes are ready to run. On the first cycle, this is the node connected to the user's input. On later cycles, it is any node whose dependencies have been satisfied.
 
-2. **Execute**: Run all ready nodes at the same time. Each node works independently — it cannot see the results of other nodes running in the same cycle. Collect the results from all nodes just executed and make them available to the next cycle
+2. **Execute**: Run all ready nodes at the same time. Each node works independently — it cannot see the results of other nodes running in the same cycle.
 
 3. **Update**: Share the results from all nodes so they're available for the next step.
 

--- a/docs/concepts/pipelines/index.md
+++ b/docs/concepts/pipelines/index.md
@@ -1,27 +1,19 @@
 # Pipelines
 
-A pipeline is a way to build a bot by combining one or more steps together.
+A **pipeline** is a visual workflow that defines how your chatbot processes a user's message and generates a response. It is made up of connected **nodes** — each node performs one task, such as calling an AI model, running custom logic, or routing the conversation to a different path. A message enters the pipeline as **input**, passes through one or more nodes, and exits as the chatbot's **output**.
 
-!!! info "Pipelines are the future"
+!!! info "Pipelines are now the standard way to build bots"
 
-    Pipelines are currently becoming the default way to build bots in Open Chat Studio. They are a superset of existing functionality, enabling complex safety layers, routing and conditionals. The transition is now underway, and we're providing communication as we begin phasing out other bot building approaches.
+    Pipelines are the default way to build bots in Open Chat Studio. They replace older approaches and support everything from simple single-step responses to complex workflows with branching, parallel steps, and safety layers.
 
-## Overview
+## A Simple Example
 
-Here is an example of a very simple pipeline that uses an LLM to respond to the users input. This pipeline has a
-single step that uses the LLM to generate a response.
+The pipeline below has a single node. The user sends a message, the LLM generates a reply, and that reply is sent back to the user. That's it.
 
 <figure markdown="span">
   ![A Simple Pipeline](../../assets/images/pipeline-basic.png)
   <figcaption>A simple pipeline</figcaption>
 </figure>
-
-Analyzing this pipeline from left to right:
-
-* the user sends a message to the bot (this is the `input`)
-* the message is then passed to the LLM which generates a response
-* the response is then sent back to the user (this is the `output`)
-
 
 ``` mermaid
 graph LR
@@ -29,28 +21,35 @@ graph LR
   B --> C@{ shape: stadium, label: "Output" };
 ```
 
-Each time a user sends a message to the bot, the pipeline is executed and the final output is sent back to the user.
+Analyzing this pipeline from left to right:
 
-Each 'step' in a pipeline is called a 'node' and pipelines can have multiple nodes. To learn more about the different
-types of nodes that can be used in a pipeline, see the [node types](nodes.md) documentation.
+* the user sends a message to the bot (this is the `input`)
+* the message is then passed to the LLM which generates a response
+* the response is then sent back to the user (this is the `output`)
 
-## Pipeline Execution
+Every time a user sends a message, the pipeline workflow runs from start to finish and the final output is sent back to the user.
+
+Each step in a pipeline is called a **node**. Pipelines can have as many nodes as your workflow requires. See [Node Types](nodes.md) for a full list of what each node can do.
+
+## How a Pipeline Runs
 
 Open Chat Studio  runs your application in organized steps. Think of it like a well-coordinated team where different parts of your application (pipeline **nodes**) communicate through shared **channels** (pipeline edges / connections).
 
-Here's how each step works:
+When a user sends a message, Open Chat Studio processes the pipeline in repeating cycles:
 
 **Plan** → **Execute** → **Update** → Repeat
 
-1. **Plan**: Decide which nodes should run next. Initially, this includes nodes that need your input data. In later steps, it includes nodes that are ready to process new information.
+1. **Plan**: Identify which nodes are ready to run. On the first cycle, this is the node connected to the user's input. On later cycles, it is any node whose dependencies have been satisfied.
 
-2. **Execute**: Run all selected nodes at the same time. Each node does its work independently and can't see changes from other nodes until the next step.
+2. **Execute**: Run all ready nodes at the same time. Each node works independently — it cannot see the results of other nodes running in the same cycle. Collect the results from all nodes just executed and make them available to the next cycle
 
 3. **Update**: Share the results from all nodes so they're available for the next step.
 
-This process repeats until either all work is complete or a step limit is reached. This approach ensures your application runs efficiently while maintaining predictable behavior.
+This repeats until all nodes have completed or a maximum step limit is reached.
 
-See [Parallel Pipelines](./parallel.md) for information about running nodes in parallel.
+!!! tip "Running nodes in parallel"
+
+    Because multiple nodes can execute in the same cycle, pipelines naturally support parallel processing. See [Parallel Pipelines](./parallel.md) for details.
 
 ## Asking the Assistant About a Pipeline
 

--- a/docs/concepts/pipelines/parallel.md
+++ b/docs/concepts/pipelines/parallel.md
@@ -71,7 +71,7 @@ The execution steps are as follows:
 
 Notice how `NodeD` gets executed twice. The first time `NodeD` runs it will have the output from `NodeC` as it's input. The 2nd time it runs it will have both the outputs from `NodeB` and `NodeC` as its inputs.
 
-To understand why this happens you need to understand the [execution model](index.md#pipeline-execution).
+To understand why this happens you need to understand the [execution model](index.md#how-a-pipeline-runs).
 
 You can manage this challenge by using a `PythonNode` with some utility functions:
 


### PR DESCRIPTION
Updates pages to clarify explanations around chatbots, pipelines, and nodes. The changes focus on making the concept pages more accessible and emphasizing the visual workflow and modularity of pipelines.

These changes make the documentation more beginner-friendly and better explain the modular, visual, and parallel nature of chatbot pipelines in Open Chat Studio.

**Key documentation improvements:**

*Clarification of chatbot and pipeline concepts:*
- Updated the definition of a chatbot to emphasize its role as an AI conversational agent, replacing the older, less clear description.
- Revised pipelines to highlight their visual workflow nature, modularity, and the use of nodes, replacing the previous flowchart analogy and removing redundant or outdated sections.
- Also removed "Pipelines are the future" as this seems outdated.

*Introduction and definition of nodes:*
- Added a clear definition for "Node" as a single processing step within a chatbot's pipeline workflow in the concepts index.
