### PR TITLE
Concept tools separate into Tech Hub Tools Reference page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,8 +84,8 @@ hide:
 
 ## Mar 18, 2026
 * **NEW** Added support for **Meta Cloud API** as a new WhatsApp messaging provider, enabling direct integration with the WhatsApp Business Platform without requiring a third-party intermediary. Configure it using your WhatsApp Business Account ID, System User Access Token, App Secret, and Webhook Verify Token.
-* **NEW** Added a [**Set Session State Key**](concepts/tools/index.md#set-session-state-key) and [**Get Session State**](concepts/tools/index.md#get-session-state-key) built-in tools that allow LLM nodes to read and write data from the [session state](concepts/sessions.md) during a conversation.
-* **NEW** Added [**Append to Session State**](concepts/tools/index.md#append-to-session-state) and [**Increment Session State Counter**](concepts/tools/index.md#increment-session-state-counter) built-in tools, mirroring the existing participant data tools for managing lists and counters in session state.
+* **NEW** Added a [**Set Session State Key**](./tech-hub/tools.md#set-session-state-key) and [**Get Session State**](./tech-hub/tools.md#get-session-state-key) built-in tools that allow LLM nodes to read and write data from the [session state](concepts/sessions.md) during a conversation.
+* **NEW** Added [**Append to Session State**](./tech-hub/tools.md#append-to-session-state) and [**Increment Session State Counter**](./tech-hub/tools.md#increment-session-state-counter) built-in tools, mirroring the existing participant data tools for managing lists and counters in session state.
 
 ## Mar 17, 2026
 * **BUG** Fixed an issue where pipelines triggered by events (e.g. conversation end, timeout) silently discarded updates to participant data, session state, and session tags. These state changes are now correctly persisted.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -63,6 +63,9 @@ the [How-to guides](../how-to/index.md).
 [Source Material](source_material.md)
 : Additional information that can be included in the bot prompt using the `{source_material}` prompt variable.
 
+[Tools](tools/index.md)
+: Tools let your chatbot take real actions during a conversation — such as performing calculations, scheduling reminders, or storing information about a participant — rather than only responding with text.
+
 [Tracing](tracing.md)
 : Tracing captures a chatbot's inputs, outputs, and decision-making process so bot developers can understand and debug their chatbot's behavior.
 

--- a/docs/concepts/participant_data.md
+++ b/docs/concepts/participant_data.md
@@ -47,7 +47,7 @@ You can manually update the participant data using the Web UI. Participant data 
 
 ### Tools
 
-Open Chat Studio provides some [tools](tools/index.md#update-participant-data) that allow bots to update the participant data. These tools are available in the "Tools"
+Open Chat Studio provides some [tools](../tech-hub/tools.md#update-participant-data) that allow bots to update the participant data. These tools are available in the "Tools"
 tab of the chatbot edit page.
 
 These tools allow the bot to update the data in real time as the user is interacting with the bot.

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -1,6 +1,6 @@
 # Tools
 
-Tools let your chatbot take real actions during a conversation — not just respond with text. When a tool is enabled, the LLM can decide to use it at the right moment, and Open Chat Studio executes it on the LLM model's behalf.
+Tools let your chatbot take real actions during a conversation — not just respond with text. When a tool is enabled, the LLM can decide to use it at the right moment, and Open Chat Studio executes the tool on the LLM model's behalf.
 
 For example, a chatbot with the Calculator tool can perform accurate arithmetic. A chatbot with reminder tools can schedule a message to be sent to the participant at a future time. Without tools, a chatbot can only generate text.
 
@@ -8,87 +8,84 @@ For example, a chatbot with the Calculator tool can perform accurate arithmetic.
 
     You choose which tools to enable for each chatbot. Only enable tools that match what your chatbot needs to do — this keeps the chatbot focused and reduces the chance of unintended actions.
 
-Tools in Open Chat Studio fall into three categories:
+## Calling a tool in a prompt
+
+Once a tool is enabled, the AI will use it when it judges it to be appropriate. You can also guide it explicitly by referring to the tool by name in your system prompt. For example:
+
+> When the participant asks to be reminded about something, use the `recurring-reminder` tool to schedule it.
+
+Each tool has a specific name. Click any tool heading below to see its name and full argument details.
+
+Tools in Open Chat Studio fall into two categories:
 
 - **[User-configurable tools](#user-configurable-tools)** — tools you enable on each chatbot
-- **[Internal tools](#internal-tools)** — tools OCS enables automatically based on your chatbot's configuration
-- **[LLM provider tools](#llm-provider-tools)** — tools provided by LLM that OCS chatbots can use
+- **[LLM provider tools](#llm-provider-tools)** — tools provided by LLM model that are available for OCS chatbots can use
 
 ## User-configurable tools
 
 These tools appear in your chatbot's node settings. Enable only the ones your chatbot needs.
 
-### Calculator
+### [Calculator](../../tech-hub/tools.md#calculator)
 
 Performs reliable mathematical calculations. Use this when your chatbot needs to compute values accurately rather than relying on the language model's estimation.
 
-### Recurring reminders
+### [Recurring reminders](../../tech-hub/tools.md#recurring-reminders)
 
 Schedules a repeating reminder for the participant — for example, a daily check-in message. You can set the start date, frequency, and an optional end date or maximum number of repetitions.
 
-### One-off reminder
+### [One-off reminder](../../tech-hub/tools.md#one-off-reminder)
 
 Schedules a single reminder message to be sent to the participant at a specific future date and time.
 
-### Delete reminder
+### [Delete reminder](../../tech-hub/tools.md#delete-reminder)
 
 Cancels an existing reminder (either a one-off or a recurring one). Use this when your chatbot should let participants cancel scheduled messages.
 
-### Move reminder date
+### [Move reminder date](../../tech-hub/tools.md#move-reminder-date)
 
 Changes the date or time of an existing reminder. Use this to let participants reschedule a reminder without deleting and recreating it.
 
-### Update participant data
+### [Update participant data](../../tech-hub/tools.md#update-participant-data)
 
 Writes a value to a participant's stored data under a specific key. Use this when the chatbot should remember something about the participant across sessions, such as a preference or a recorded response.
 
 See [Participant Data](../participant_data.md) for more information.
 
-### Append to participant data
+### [Append to participant data](../../tech-hub/tools.md#append-to-participant-data)
 
 Adds a value to participant data at a specific key. If the key does not yet exist, it is created as a list. Use this to track multiple items over time — for example, a list of topics a participant has mentioned.
 
 See [Participant Data](../participant_data.md) for more information.
 
-### Increment counter
+### [Increment counter](../../tech-hub/tools.md#increment-counter)
 
 Increments a numeric counter stored in participant data. Use this to track how many times something has happened across sessions — for example, how many check-ins a participant has completed.
 
 See [Participant Data](../participant_data.md) for more information.
 
-### Set session state key
+### [Set session state key](../../tech-hub/tools.md#set-session-state-key)
 
 Stores a key-value pair in the session state, which persists for the duration of the current session. Useful in pipeline configurations where one part of the conversation needs to pass information to another.
 
-### Get session state key
+### [Get session state key](../../tech-hub/tools.md#get-session-state-key)
 
 Retrieves a value previously stored in session state during the current session.
 
-### Append to session state
+### [Append to session state](../../tech-hub/tools.md#append-to-session-state)
 
 Adds a value to a list in the session state at a specific key. Use this to track items within a single session — for example, a list of topics discussed so far.
 
 See [Sessions](../sessions.md) for more information.
 
-### Increment session state counter
+### [Increment session state counter](../../tech-hub/tools.md#increment-session-state-counter)
 
 Increments a numeric counter stored in session state. Use this to count events within a single session.
 
-### End session
+### [End session](../../tech-hub/tools.md#end-session)
 
 Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete.
 
 See [Sessions](../sessions.md) for more information.
-
-## Internal tools
-
-The following tools are managed automatically by Open Chat Studio. You do not enable or configure them directly — OCS enables them when your chatbot's configuration requires them.
-
-**Attach media** is enabled when your chatbot has a media collection configured. It allows the chatbot to attach files from that collection to a response.
-
-**File search** is enabled when your chatbot has an indexed collection configured. It allows the chatbot to search indexed documents and include relevant information in its response.
-
-See [Collections](../../concepts/collections/index.md) for more information on configuring media and indexed collections.
 
 ## LLM provider tools
 

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -1,196 +1,102 @@
 # Tools
 
-Tools allow LLMs to affect change in the real world. An LLM on its own can only produce intentions, but it is not able to execute those intentions. *Tools* are a way of telling the LLM what requests it can make and of executing that request when it is made.
+Tools let your chatbot take real actions during a conversation — not just respond with text. When a tool is enabled, the LLM can decide to use it at the right moment, and Open Chat Studio executes it on the LLM model's behalf.
 
-Open Chat Studio provides a number of built-in tools as well as the ability to add your own tools in the form of [Custom Actions](../llm_custom_action.md).
+For example, a chatbot with the Calculator tool can perform accurate arithmetic. A chatbot with reminder tools can schedule a message to be sent to the participant at a future time. Without tools, a chatbot can only generate text.
 
-The current set of built-in tools are listed below. If you need to refer to the tool in a prompt, use the tool's name directly e.g. `update-user-data`.
+!!! tip
 
-## User configurable tools
+    You choose which tools to enable for each chatbot. Only enable tools that match what your chatbot needs to do — this keeps the chatbot focused and reduces the chance of unintended actions.
+
+Tools in Open Chat Studio fall into three categories:
+
+- **[User-configurable tools](#user-configurable-tools)** — tools you enable on each chatbot
+- **[Internal tools](#internal-tools)** — tools OCS enables automatically based on your chatbot's configuration
+- **[LLM provider tools](#llm-provider-tools)** — tools provided by LLM that OCS chatbots can use
+
+## User-configurable tools
+
+These tools appear in your chatbot's node settings. Enable only the ones your chatbot needs.
 
 ### Calculator
 
-Allows to bot to do mathematical calculations reliably.
-
-* Name: `calculator`
-* Arguments:
-  * `expression`: The mathematical expression to evaluate.
+Performs reliable mathematical calculations. Use this when your chatbot needs to compute values accurately rather than relying on the language model's estimation.
 
 ### Recurring reminders
 
-Allows the bot to schedule recurring reminders for the participant.
+Schedules a repeating reminder for the participant — for example, a daily check-in message. You can set the start date, frequency, and an optional end date or maximum number of repetitions.
 
-* Name: `recurring-reminder`
-* Arguments:
-  * `datetime_due`: The first (or only) reminder start date in ISO 8601 format.
-  * `every`: Number of 'periods' to wait between reminders.
-  * `period`: The time period used in conjunction with 'every'. One of `minutes`, `hours`, `days`, `weeks`, `months`
-  * `message`: The reminder message.
-  * `schedule_name`: The name for this reminder.
-  * `datetime_end`: The date of the last reminder in ISO 8601 format (optional).
-  * `repetitions`: The number of messages to send before stopping (optional).
+### One-off reminder
 
-### One-off Reminder
+Schedules a single reminder message to be sent to the participant at a specific future date and time.
 
-Allows the bot to schedule once-off reminders for the participant.
+### Delete reminder
 
-* Name: `one-off-reminder`
-* Arguments:
-  * `datetime_due`: The datetime that the reminder is due in ISO 8601 format
-  * `message`: The reminder message
-  * `schedule_name`: The name for this reminder
+Cancels an existing reminder (either a one-off or a recurring one). Use this when your chatbot should let participants cancel scheduled messages.
 
-### Delete Reminder
+### Move reminder date
 
-Allows the bot to delete existing reminders (either once-off or recurring)
+Changes the date or time of an existing reminder. Use this to let participants reschedule a reminder without deleting and recreating it.
 
-* Name: `delete-reminder`
-* Arguments:
-  * `message_id`: The ID of the scheduled message to delete.
+### Update participant data
 
-### Move Reminder Date
+Writes a value to a participant's stored data under a specific key. Use this when the chatbot should remember something about the participant across sessions, such as a preference or a recorded response.
 
-Allows the bot to update the reminder date
+See [Participant Data](../participant_data.md) for more information.
 
-* Name: `move-scheduled-message-date`
-* Arguments:
-  * `message_id`: The ID of the scheduled message to update.
-  * `weekday`: The new day of the week (1-7 where 1 = Monday).
-  * `hour`: The new hour of the day, in UTC.
-  * `minute`: The new minute of the hour.
-  * `specified_date`: A specific date to re-schedule the message for in ISO 8601 format
+### Append to participant data
 
-### Update Participant Data
+Adds a value to participant data at a specific key. If the key does not yet exist, it is created as a list. Use this to track multiple items over time — for example, a list of topics a participant has mentioned.
 
-Allows the bot to make changes to the [participant data](../participant_data.md)
+See [Participant Data](../participant_data.md) for more information.
 
-* Name: `update-user-data`
-* Arguments:
-  * `key`: The key in the user data to update.
-  * `value`: The new value of the user data.
+### Increment counter
 
-### Append to Participant Data
+Increments a numeric counter stored in participant data. Use this to track how many times something has happened across sessions — for example, how many check-ins a participant has completed.
 
-Append a value to [participant data](../participant_data.md) at a specific key. This will convert any existing value to a list and append the new value to the end of the list. Use this tool to track lists of items e.g. questions asked.
+See [Participant Data](../participant_data.md) for more information.
 
-* Name: `append-to-participant-data`
-* Arguments:
-  * `key`: The key in the user data to append to.
-  * `value`: The value to append.
+### Set session state key
 
-### Increment Counter
+Stores a key-value pair in the session state, which persists for the duration of the current session. Useful in pipeline configurations where one part of the conversation needs to pass information to another.
 
-Increment the value of a counter. The counter is stored in [participant data](../participant_data.md) with the key `_counter_{counter_name}`.
+### Get session state key
 
-* Name: `increment-counter`
-* Arguments:
-  * `counter`: The name of the counter to increment.
-  * `value`: Integer value to increment the counter by (defaults to 1).
+Retrieves a value previously stored in session state during the current session.
 
-### Set Session State Key
+### Append to session state
 
-Allows the bot to set a key-value pair in the session state. The session state persists for the duration of the session and can be used to store and retrieve data across conversation turns, particularly useful in pipeline configurations.
+Adds a value to a list in the session state at a specific key. Use this to track items within a single session — for example, a list of topics discussed so far.
 
-* Name: `set-session-state-key`
-* Arguments:
-  * `key`: The key in the session state to set.
-  * `value`: The value to store at the specified key.
+See [Sessions](../sessions.md) for more information.
 
-### Get Session State Key
+### Increment session state counter
 
-Allows the bot to get a value from the session state.
+Increments a numeric counter stored in session state. Use this to count events within a single session.
 
-* Name: `get-session-state`
-* Arguments:
-  * `key`: The key in the session state to get the value for.
+### End session
 
-### Append to Session State
+Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete.
 
-Append a value to [session state](../sessions.md) at a specific key. This will convert any existing value to a list and append the new value to the end of the list. Use this tool to track lists of items within a session e.g. topics discussed.
-
-* Name: `append-to-session-state`
-* Arguments:
-  * `key`: The key in the session state to append to.
-  * `value`: The value to append.
-
-### Increment Session State Counter
-
-Increment the value of a counter stored in [session state](../sessions.md). The counter is stored with the key `_counter_{counter_name}`.
-
-* Name: `increment-session-state-counter`
-* Arguments:
-  * `counter`: The name of the counter to increment.
-  * `value`: Integer value to increment the counter by (defaults to 1).
-
-### End Session
-
-End the current chat [session](../sessions.md). This will mark the session as completed. New messages will result in a new session being created.
-
-* Name: `end-session`
-* Arguments: (none)
+See [Sessions](../sessions.md) for more information.
 
 ## Internal tools
 
-The following tools are used internally by Open Chat Studio and enabled / disabled automatically depending on the chatbot configuration.
+The following tools are managed automatically by Open Chat Studio. You do not enable or configure them directly — OCS enables them when your chatbot's configuration requires them.
 
-### Attach Media
+**Attach media** is enabled when your chatbot has a media collection configured. It allows the chatbot to attach files from that collection to a response.
 
-Allows the bot to attach media when a media collection is configured. 
+**File search** is enabled when your chatbot has an indexed collection configured. It allows the chatbot to search indexed documents and include relevant information in its response.
 
-* Name: `attach-media`
-* Arguments:
-  * `file_id`: The ID of the media file to attach.
+See [Collections](../../concepts/collections/index.md) for more information on configuring media and indexed collections.
 
-### File Search
+## LLM provider tools
 
-Allows the bot to search indexed collections when a collection is configured.
+Some LLM providers offer their own built-in tools — such as web search or code execution — that run inside the provider's infrastructure. Open Chat Studio can connect to some of these where the provider supports it.
 
-* Name: `file-search`
-* Arguments:
-  * `query`: A natural language query to search for relevant information in the documents.
+Support varies by provider. The full list of provider tools and their current support status is in the [Tools Reference](../../tech-hub/tools.md#llm-provider-tools).
 
-## LLM Provider Tools
+## Next steps
 
-In addition to the tools provided by Open Chat Studio, some LLM providers have their own set of tools which are executed interally by the provider.
-
-### OpenAI tools
-
-#### Web Search { #openai-web-search }
-
-* Search the web and pass the results to the LLM.
-* See https://platform.openai.com/docs/guides/tools-web-search
-* :material-check-circle-outline:{ .green } Supported by OCS
-
-#### Code Interpreter { #openai-code-interpreter }
-
-* Execute code to analyse data, generate graphs etc.
-* See https://platform.openai.com/docs/guides/tools-code-interpreter
-* :material-check-circle-outline:{ .green } Supported by OCS
-
-### Anthropic tools
-
-#### Web Search { #anthropic-web-search }
-
-* Search the web and pass the results to the LLM.
-* See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool
-* :material-check-circle-outline:{ .green } Supported by OCS
-
-#### Code Execution { #anthropic-code-execution }
-
-* Execute code to analyse data, generate graphs etc.
-* See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/code-execution-tool
-* :octicons-x-circle-24:{ .red } Not supported by OCS
-
-### Gemini tools
-
-#### Grounding with search { #gemini-web-search }
-
-* Search the web and pass the results to the LLM.
-* See https://ai.google.dev/gemini-api/docs/google-search
-* :octicons-x-circle-24:{ .red } Not supported by OCS
-
-#### Code Execution { #gemini-code-execution }
-
-* Execute code to analyse data, generate graphs etc.
-* See https://ai.google.dev/gemini-api/docs/code-execution
-* :octicons-x-circle-24:{ .red } Not supported by OCS
+- To see full argument details for each user-configurable tool, see the [Tools Reference](../../tech-hub/tools.md).
+- To add your own tools in the form of custom integrations, see [Custom Actions](../llm_custom_action.md).

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -14,84 +14,41 @@ Once a tool is enabled, the AI will use it when it judges it to be appropriate. 
 
 > When the participant asks to be reminded about something, use the `recurring-reminder` tool to schedule it.
 
-Each tool has a specific name. Click any tool heading below to see its name and full argument details.
+Each tool name below links to its full argument details in the [Tools Reference](../../tech-hub/tools.md).
 
 Tools in Open Chat Studio fall into two categories:
 
 - **[User-configurable tools](#user-configurable-tools)** — tools you enable on each chatbot
-- **[LLM provider tools](#llm-provider-tools)** — tools provided by LLM model that are available for OCS chatbots can use
+- **[LLM provider tools](#llm-provider-tools)** — tools provided by AI models that are available for OCS chatbots to use
 
 ## User-configurable tools
 
 These tools appear in your chatbot's node settings. Enable only the ones your chatbot needs.
 
-### [Calculator](../../tech-hub/tools.md#calculator)
+- **[Calculator](../../tech-hub/tools.md#calculator)** — Performs reliable mathematical calculations. Use this when your chatbot needs to compute values accurately rather than relying on the language model's estimation.
+- **[Recurring reminders](../../tech-hub/tools.md#recurring-reminders)** — Schedules a repeating reminder for the participant — for example, a daily check-in message. You can set the start date, frequency, and an optional end date or maximum number of repetitions.
+- **[One-off reminder](../../tech-hub/tools.md#one-off-reminder)** — Schedules a single reminder message to be sent to the participant at a specific future date and time.
+- **[Delete reminder](../../tech-hub/tools.md#delete-reminder)** — Cancels an existing reminder (either a one-off or a recurring one). Use this when your chatbot should let participants cancel scheduled messages.
+- **[Move reminder date](../../tech-hub/tools.md#move-reminder-date)** — Changes the date or time of an existing reminder. Use this to let participants reschedule a reminder without deleting and recreating it.
+- **[Update participant data](../../tech-hub/tools.md#update-participant-data)** — Writes a value to a participant's stored data under a specific key. Use this when the chatbot should remember something about the participant across sessions, such as a preference or a recorded response. See [Participant Data](../participant_data.md) for more information.
+- **[Append to participant data](../../tech-hub/tools.md#append-to-participant-data)** — Adds a value to participant data at a specific key. Use this to track multiple items over time — for example, a list of topics a participant has mentioned. See [Participant Data](../participant_data.md) for more information.
+- **[Increment counter](../../tech-hub/tools.md#increment-counter)** — Increments a numeric counter stored in participant data. Use this to track how many times something has happened across sessions — for example, how many check-ins a participant has completed. See [Participant Data](../participant_data.md) for more information.
+- **[Set session state key](../../tech-hub/tools.md#set-session-state-key)** — Stores a key-value pair in the session state, which persists for the duration of the current session. Useful in pipeline configurations where one part of the conversation needs to pass information to another.
+- **[Get session state key](../../tech-hub/tools.md#get-session-state-key)** — Retrieves a value previously stored in session state during the current session.
+- **[Append to session state](../../tech-hub/tools.md#append-to-session-state)** — Adds a value to a list in the session state. Use this to track items within a single session — for example, a list of topics discussed so far. See [Sessions](../sessions.md) for more information.
+- **[Increment session state counter](../../tech-hub/tools.md#increment-session-state-counter)** — Increments a numeric counter stored in session state. Use this to count events within a single session.
+- **[End session](../../tech-hub/tools.md#end-session)** — Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete. See [Sessions](../sessions.md) for more information.
 
-Performs reliable mathematical calculations. Use this when your chatbot needs to compute values accurately rather than relying on the language model's estimation.
-
-### [Recurring reminders](../../tech-hub/tools.md#recurring-reminders)
-
-Schedules a repeating reminder for the participant — for example, a daily check-in message. You can set the start date, frequency, and an optional end date or maximum number of repetitions.
-
-### [One-off reminder](../../tech-hub/tools.md#one-off-reminder)
-
-Schedules a single reminder message to be sent to the participant at a specific future date and time.
-
-### [Delete reminder](../../tech-hub/tools.md#delete-reminder)
-
-Cancels an existing reminder (either a one-off or a recurring one). Use this when your chatbot should let participants cancel scheduled messages.
-
-### [Move reminder date](../../tech-hub/tools.md#move-reminder-date)
-
-Changes the date or time of an existing reminder. Use this to let participants reschedule a reminder without deleting and recreating it.
-
-### [Update participant data](../../tech-hub/tools.md#update-participant-data)
-
-Writes a value to a participant's stored data under a specific key. Use this when the chatbot should remember something about the participant across sessions, such as a preference or a recorded response.
-
-See [Participant Data](../participant_data.md) for more information.
-
-### [Append to participant data](../../tech-hub/tools.md#append-to-participant-data)
-
-Adds a value to participant data at a specific key. If the key does not yet exist, it is created as a list. Use this to track multiple items over time — for example, a list of topics a participant has mentioned.
-
-See [Participant Data](../participant_data.md) for more information.
-
-### [Increment counter](../../tech-hub/tools.md#increment-counter)
-
-Increments a numeric counter stored in participant data. Use this to track how many times something has happened across sessions — for example, how many check-ins a participant has completed.
-
-See [Participant Data](../participant_data.md) for more information.
-
-### [Set session state key](../../tech-hub/tools.md#set-session-state-key)
-
-Stores a key-value pair in the session state, which persists for the duration of the current session. Useful in pipeline configurations where one part of the conversation needs to pass information to another.
-
-### [Get session state key](../../tech-hub/tools.md#get-session-state-key)
-
-Retrieves a value previously stored in session state during the current session.
-
-### [Append to session state](../../tech-hub/tools.md#append-to-session-state)
-
-Adds a value to a list in the session state at a specific key. Use this to track items within a single session — for example, a list of topics discussed so far.
-
-See [Sessions](../sessions.md) for more information.
-
-### [Increment session state counter](../../tech-hub/tools.md#increment-session-state-counter)
-
-Increments a numeric counter stored in session state. Use this to count events within a single session.
-
-### [End session](../../tech-hub/tools.md#end-session)
-
-Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete.
-
-See [Sessions](../sessions.md) for more information.
 
 ## LLM provider tools
 
 Some LLM providers offer their own built-in tools — such as web search or code execution — that run inside the provider's infrastructure. Open Chat Studio can connect to some of these where the provider supports it.
 
 Support varies by provider. The full list of provider tools and their current support status is in the [Tools Reference](../../tech-hub/tools.md#llm-provider-tools).
+
+## OCS Internal tools
+
+Open Chat Studio also manages a small set of internal tools automatically - `Attach media` and `File Search`. See the [Tools Reference](../../tech-hub/tools.md#internal-tools) for details.
 
 ## Next steps
 

--- a/docs/how-to/assistants_migration.md
+++ b/docs/how-to/assistants_migration.md
@@ -9,7 +9,7 @@ Open Chat Studio supports all the features of Assistants in alternative ways as 
 | Assistant Feature | Replacement Feature                                                                             |
 |-------------------|-------------------------------------------------------------------------------------------------|
 | Threads           | Open Chat Studio [sessions](../concepts/sessions.md)                                            |
-| Code Interpreter  | [OpenAI Code Interpreter tool](../tech-hub/tools.md#openai-tools) in LLM nodes |
+| Code Interpreter  | [OpenAI Code Interpreter tool](../tech-hub/tools.md#openai-code-interpreter) in LLM nodes |
 | File Search       | [Indexed Collections](../concepts/collections/indexed.md)                                       |
 
 

--- a/docs/how-to/assistants_migration.md
+++ b/docs/how-to/assistants_migration.md
@@ -9,7 +9,7 @@ Open Chat Studio supports all the features of Assistants in alternative ways as 
 | Assistant Feature | Replacement Feature                                                                             |
 |-------------------|-------------------------------------------------------------------------------------------------|
 | Threads           | Open Chat Studio [sessions](../concepts/sessions.md)                                            |
-| Code Interpreter  | [OpenAI Code Interpreter tool](../concepts/tools/index.md#openai-code-interpreter) in LLM nodes |
+| Code Interpreter  | [OpenAI Code Interpreter tool](../tech-hub/tools.md#openai-tools) in LLM nodes |
 | File Search       | [Indexed Collections](../concepts/collections/indexed.md)                                       |
 
 

--- a/docs/tech-hub/index.md
+++ b/docs/tech-hub/index.md
@@ -16,5 +16,6 @@ These topics contain technical facts and code examples.
 - **[Custom Actions](custom_action/index.md)** — Integrate external services into chatbots via OpenAPI schemas. Covers configuration, health monitoring, and testing of Custom Actions.
 - **[Calling External APIs](external-api-calls/index.md)** — Use the built-in HTTP client inside Python nodes to securely call third-party APIs from a Pipeline workflow.
 - **[Python Node](python_node.md)** — Write custom Python code inside a Pipeline to perform logic, process data, manage session state, and make HTTP requests to external services.
+- **[Tools Reference](tools.md)** — Full argument reference for all built-in tools and the LLM provider tools supported. For a conceptual overview, see [Tools Concepts](../concepts/tools/index.md)
 - **[OCS API Access](api_access.md)** — Interact with OCS chatbots programmatically using the REST API. Useful for third-party integrations and automated evaluation.
 

--- a/docs/tech-hub/index.md
+++ b/docs/tech-hub/index.md
@@ -16,6 +16,6 @@ These topics contain technical facts and code examples.
 - **[Custom Actions](custom_action/index.md)** — Integrate external services into chatbots via OpenAPI schemas. Covers configuration, health monitoring, and testing of Custom Actions.
 - **[Calling External APIs](external-api-calls/index.md)** — Use the built-in HTTP client inside Python nodes to securely call third-party APIs from a Pipeline workflow.
 - **[Python Node](python_node.md)** — Write custom Python code inside a Pipeline to perform logic, process data, manage session state, and make HTTP requests to external services.
-- **[Tools Reference](tools.md)** — Full argument reference for all built-in tools and the LLM provider tools supported. For a conceptual overview, see [Tools Concepts](../concepts/tools/index.md)
+- **[Tools Reference](tools.md)** — Full argument reference for all built-in tools and the LLM provider tools supported. For a conceptual overview, see [Tools Concepts](../concepts/tools/index.md).
 - **[OCS API Access](api_access.md)** — Interact with OCS chatbots programmatically using the REST API. Useful for third-party integrations and automated evaluation.
 

--- a/docs/tech-hub/tools.md
+++ b/docs/tech-hub/tools.md
@@ -1,0 +1,209 @@
+# Tools Reference
+
+This page is a full technical reference for the built-in tools available in Open Chat Studio.
+
+For a plain-English overview of what each tool does and when to use it, see [Tools](../concepts/tools/index.md).
+
+## Quick reference
+
+To instruct the model to use a specific tool, refer to it by its tool name in your system prompt. For example:
+
+> When the user asks to be reminded, use the `recurring-reminder` tool.
+
+### User-configurable tools
+
+| Tool | Name | Description |
+|------|------|-------------|
+| [Calculator](#calculator) | `calculator` | Performs mathematical calculations |
+| [Recurring reminders](#recurring-reminders) | `recurring-reminder` | Schedules a repeating reminder |
+| [One-off reminder](#one-off-reminder) | `one-off-reminder` | Schedules a single reminder |
+| [Delete reminder](#delete-reminder) | `delete-reminder` | Cancels an existing reminder |
+| [Move reminder date](#move-reminder-date) | `move-scheduled-message-date` | Reschedules an existing reminder |
+| [Update participant data](#update-participant-data) | `update-user-data` | Writes a value to participant data |
+| [Append to participant data](#append-to-participant-data) | `append-to-participant-data` | Appends a value to a list in participant data |
+| [Increment counter](#increment-counter) | `increment-counter` | Increments a counter in participant data |
+| [Set session state key](#set-session-state-key) | `set-session-state-key` | Stores a key-value pair in session state |
+| [Get session state key](#get-session-state-key) | `get-session-state` | Retrieves a value from session state |
+| [Append to session state](#append-to-session-state) | `append-to-session-state` | Appends a value to a list in session state |
+| [Increment session state counter](#increment-session-state-counter) | `increment-session-state-counter` | Increments a counter in session state |
+| [End session](#end-session) | `end-session` | Marks the current session as complete |
+
+### LLM provider tools
+
+| Provider | Tool | Supported |
+|----------|------|-----------|
+| OpenAI | [Web Search](#openai-web-search) | :material-check-circle-outline:{ .green } Yes |
+| OpenAI | [Code Interpreter](#openai-code-interpreter) | :material-check-circle-outline:{ .green } Yes |
+| Anthropic | [Web Search](#anthropic-web-search) | :material-check-circle-outline:{ .green } Yes |
+| Anthropic | [Code Execution](#anthropic-code-execution) | :octicons-x-circle-24:{ .red } No |
+| Gemini | [Grounding with Search](#gemini-web-search) | :octicons-x-circle-24:{ .red } No |
+| Gemini | [Code Execution](#gemini-code-execution) | :octicons-x-circle-24:{ .red } No |
+
+## User-configurable tools
+
+### Calculator
+
+Allows the bot to perform mathematical calculations reliably.
+
+- Name: `calculator`
+- Arguments:
+    - `expression`: The mathematical expression to evaluate.
+
+### Recurring reminders
+
+Allows the bot to schedule recurring reminders for the participant.
+
+- Name: `recurring-reminder`
+- Arguments:
+    - `datetime_due`: The first (or only) reminder start date in ISO 8601 format.
+    - `every`: Number of 'periods' to wait between reminders.
+    - `period`: The time period used in conjunction with `every`. One of `minutes`, `hours`, `days`, `weeks`, `months`.
+    - `message`: The reminder message.
+    - `schedule_name`: The name for this reminder.
+    - `datetime_end`: The date of the last reminder in ISO 8601 format (optional).
+    - `repetitions`: The number of messages to send before stopping (optional).
+
+### One-off reminder
+
+Allows the bot to schedule a once-off reminder for the participant.
+
+- Name: `one-off-reminder`
+- Arguments:
+    - `datetime_due`: The datetime that the reminder is due in ISO 8601 format.
+    - `message`: The reminder message.
+    - `schedule_name`: The name for this reminder.
+
+### Delete reminder
+
+Allows the bot to delete an existing reminder (either once-off or recurring).
+
+- Name: `delete-reminder`
+- Arguments:
+    - `message_id`: The ID of the scheduled message to delete.
+
+### Move reminder date
+
+Allows the bot to update the date or time of an existing reminder.
+
+- Name: `move-scheduled-message-date`
+- Arguments:
+    - `message_id`: The ID of the scheduled message to update.
+    - `weekday`: The new day of the week (1–7, where 1 = Monday).
+    - `hour`: The new hour of the day, in UTC.
+    - `minute`: The new minute of the hour.
+    - `specified_date`: A specific date to reschedule the message for in ISO 8601 format.
+
+### Update participant data
+
+Allows the bot to write a value to [participant data](../concepts/participant_data.md) at a specific key.
+
+- Name: `update-user-data`
+- Arguments:
+    - `key`: The key in the participant data to update.
+    - `value`: The new value to store.
+
+### Append to participant data
+
+Appends a value to [participant data](../concepts/participant_data.md) at a specific key. Converts any existing value to a list and appends the new value to the end.
+
+- Name: `append-to-participant-data`
+- Arguments:
+    - `key`: The key in the participant data to append to.
+    - `value`: The value to append.
+
+### Increment counter
+
+Increments a numeric counter stored in [participant data](../concepts/participant_data.md). The counter is stored under the key `_counter_{counter_name}`.
+
+- Name: `increment-counter`
+- Arguments:
+    - `counter`: The name of the counter to increment.
+    - `value`: Integer value to increment the counter by (defaults to 1).
+
+### Set session state key
+
+Allows the bot to set a key-value pair in the [session state](../concepts/sessions.md). Session state persists for the duration of the session and is useful in pipeline configurations for passing data across conversation turns.
+
+- Name: `set-session-state-key`
+- Arguments:
+    - `key`: The key in the session state to set.
+    - `value`: The value to store at the specified key.
+
+### Get session state key
+
+Allows the bot to retrieve a value from the [session state](../concepts/sessions.md).
+
+- Name: `get-session-state`
+- Arguments:
+    - `key`: The key in the session state to retrieve.
+
+### Append to session state
+
+Appends a value to [session state](../concepts/sessions.md) at a specific key. Converts any existing value to a list and appends the new value to the end.
+
+- Name: `append-to-session-state`
+- Arguments:
+    - `key`: The key in the session state to append to.
+    - `value`: The value to append.
+
+### Increment session state counter
+
+Increments a numeric counter stored in [session state](../concepts/sessions.md). The counter is stored under the key `_counter_{counter_name}`.
+
+- Name: `increment-session-state-counter`
+- Arguments:
+    - `counter`: The name of the counter to increment.
+    - `value`: Integer value to increment the counter by (defaults to 1).
+
+### End session
+
+Ends the current chat [session](../concepts/sessions.md). The session is marked as completed. New messages will start a fresh session.
+
+- Name: `end-session`
+- Arguments: (none)
+
+## LLM provider tools
+
+Some LLM providers offer their own built-in tools that run inside the provider's infrastructure.
+
+### OpenAI tools
+
+#### Web Search { #openai-web-search }
+
+- Search the web and pass the results to the LLM.
+- See [OpenAI Web Search documentation](https://platform.openai.com/docs/guides/tools-web-search)
+- :material-check-circle-outline:{ .green } Supported by OCS
+
+#### Code Interpreter { #openai-code-interpreter }
+
+- Execute code to analyse data, generate graphs, and more.
+- See [OpenAI Code Interpreter documentation](https://platform.openai.com/docs/guides/tools-code-interpreter)
+- :material-check-circle-outline:{ .green } Supported by OCS
+
+### Anthropic tools
+
+#### Web Search { #anthropic-web-search }
+
+- Search the web and pass the results to the LLM.
+- See [Anthropic Web Search documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool)
+- :material-check-circle-outline:{ .green } Supported by OCS
+
+#### Code Execution { #anthropic-code-execution }
+
+- Execute code to analyse data, generate graphs, and more.
+- See [Anthropic Code Execution documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/code-execution-tool)
+- :octicons-x-circle-24:{ .red } Not supported by OCS
+
+### Gemini tools
+
+#### Grounding with search { #gemini-web-search }
+
+- Search the web and pass the results to the LLM.
+- See [Gemini Grounding with Search documentation](https://ai.google.dev/gemini-api/docs/google-search)
+- :octicons-x-circle-24:{ .red } Not supported by OCS
+
+#### Code Execution { #gemini-code-execution }
+
+- Execute code to analyse data, generate graphs, and more.
+- See [Gemini Code Execution documentation](https://ai.google.dev/gemini-api/docs/code-execution)
+- :octicons-x-circle-24:{ .red } Not supported by OCS

--- a/docs/tech-hub/tools.md
+++ b/docs/tech-hub/tools.md
@@ -162,6 +162,28 @@ Ends the current chat [session](../concepts/sessions.md). The session is marked 
 - Name: `end-session`
 - Arguments: (none)
 
+## Internal tools
+
+The following tools are managed automatically by Open Chat Studio. You do not enable or configure them directly — OCS enables them when your chatbot's configuration requires them.
+
+### Attach media
+
+Allows the bot to attach media when a media collection is configured.
+
+- Name: `attach-media`
+- Arguments:
+    - `file_id`: The ID of the media file to attach.
+
+### File search
+
+Allows the bot to search indexed collections when a collection is configured.
+
+- Name: `file-search`
+- Arguments:
+    - `query`: A natural language query to search for relevant information in the documents.
+
+See [Collections](../concepts/collections/index.md) for more information on configuring media and indexed collections.
+
 ## LLM provider tools
 
 Some LLM providers offer their own built-in tools that run inside the provider's infrastructure.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,9 +164,10 @@ nav:
         - Annotating: concepts/annotations/annotating.md
   - Tech Hub:
     - tech-hub/index.md
+    - Tools Reference: tech-hub/tools.md
     - Python Node: tech-hub/python_node.md
-    - Call External APIs: 
-        - tech-hub/external-api-calls/index.md     
+    - Call External APIs:
+        - tech-hub/external-api-calls/index.md
         - HTTP Client: tech-hub/external-api-calls/http_client.md
     - Custom Actions:
         - tech-hub/custom_action/index.md


### PR DESCRIPTION
This improves the docs for OCS Tools by providing a clearer conceptual overview and separate technical reference. 
Resolves https://github.com/dimagi/open-chat-studio-docs/issues/380

**Major documentation improvements:**

*Conceptual and technical documentation separation:*
- Completely rewrote `docs/concepts/tools/index.md` to focus on a plain-English, user-friendly conceptual overview of tools, how they work, and when to use them. The page now clearly distinguishes between user-configurable tools and LLM provider tools, and links out to the new technical reference for detailed arguments and usage.
- NOTE: _**Internal Tools**_ section should not be needed by most users, so all details in Tech-Hub

- Added a new `docs/tech-hub/tools.md` page as a full technical reference for all built-in tools, internal tools and LLM provider tools. This page includes argument details, tool names, and support status for each provider, as well as tables for quick lookup and detailed sections for each tool.

- Updated internal links 

