### PR TITLE
Separated out  session reset to a How To Guide

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -1,6 +1,6 @@
 # Events
 
-Open Chat Studio provides an event system that allows you to define actions triggered by specific events within a chat session. This functionality enables you to automate responses, manage session states, and enhance user interactions effectively.
+Open Chat Studio provides an event system that allows you to define actions triggered by specific events within a [chat session](sessions.md). This functionality enables you to automate responses, manage session states, and enhance user interactions effectively.
 
 ## Overview
 
@@ -37,7 +37,7 @@ Static events are predefined triggers that occur based on specific actions or co
 
 Each event is associated with one action. The available actions are:
 
-- **End the conversation**: Ends the conversation with the user. See [Resetting Sessions](sessions.md#resetting-sessions).
+- **End the conversation**: Ends the conversation with the user. See [Resetting Sessions](sessions.md#resetting-sessions) and [Session Status](session_status.md).
 - **Prompt the bot to message the user**: Prompts the bot to message the user.
 - **Trigger a schedule**: This will create a once off or recurring schedule. Each time the schedule is triggered, the bot will be prompted to message the user.
 - **Start a pipeline**: This will run the given pipeline when the event triggers. The input to the pipeline can be configured.

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -37,7 +37,7 @@ Static events are predefined triggers that occur based on specific actions or co
 
 Each event is associated with one action. The available actions are:
 
-- **End the conversation**: Ends the conversation with the user. See [Resetting Sessions](sessions.md#resetting-sessions) and [Session Status](session_status.md).
+- **End the conversation**: Ends the conversation with the user. See [How to reset sessions](../how-to/reset_sessions.md) and [Session Status](session_status.md).
 - **Prompt the bot to message the user**: Prompts the bot to message the user.
 - **Trigger a schedule**: This will create a once off or recurring schedule. Each time the schedule is triggered, the bot will be prompted to message the user.
 - **Start a pipeline**: This will run the given pipeline when the event triggers. The input to the pipeline can be configured.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -60,6 +60,9 @@ the [How-to guides](../how-to/index.md).
 [Session](sessions.md)
 : The scope of conversations between a user and a chatbot within a specific channel. Sessions are isolated, ensuring data privacy and contextual continuity for the duration of an interaction.
 
+[Session Status](session_status.md)
+: The lifecycle state of a chat session (for example, setup, active, pending review, complete) and the transitions between those states.
+
 [Source Material](source_material.md)
 : Additional information that can be included in the bot prompt using the `{source_material}` prompt variable.
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -43,37 +43,15 @@ On the **Web** channel, users can have **anonymous sessions**, where:
 
 ## Resetting Sessions
 
-For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current session continues indefinitely. However, sessions can be reset either manually by the user or automatically using [Events](events.md) or the API. When a session is reset:
+For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current session continues until it is explicitly ended. 
 
-- The current session is marked as completed.
+However, sessions can be reset either [manually](../how-to/reset_sessions.md#reset-a-session-manually) by the user or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically). 
+
+When a session is reset:
+
+- The current session is marked as [completed](./session_status.md#complete).
 - A new session is started with a fresh history.
-
-For a detailed breakdown of session states and transitions, see [Session Status](session_status.md).
 
 This means that, aside from participant data, the bot loses all information about the previous conversation — including the fact that it even took place.
 
-### Manual resets
-
-Users can manually reset a session (start a new session) in two ways:
-
-#### Using the `/reset` command
-
-The `/reset` command allows chat users to start a new session by sending this text command in the chat. This command is available on all channels except **Web** and **Slack**.
-
-#### Using the session reset button
-
-In the web interface, users have access to a button that allows them to end the current session and immediately start a new one. When using this button, users can:
-
-- **Choose whether to trigger end conversation events**: Users can opt to run any configured [end conversation events](events.md) before starting the new session, or skip them.
-- **Provide an initial bot message**: Users must specify a prompt that will be used as the bot's first message in the new session. If the chatbot has a seed message configured, this field will be pre-filled with that seed message, but users can modify it as needed.
-
-This button provides more control over the session reset process compared to the `/reset` command, allowing users to customize how the transition between sessions occurs.
-
-### Automatic resets
-
-There are two ways to automatically reset a session:
-
-- **Events**: You can configure an event to end the current session when the event is triggered. This will not automatically create a new session; however, if the user sends a message after the session is ended, a new session will be created. See [Events](events.md).
-- **API**: When using the [Trigger Bot Message](https://openchatstudio.com/api/docs/#tag/Channels/operation/trigger_bot_message) API, you can set `"start_new_session": true`, which will end the current session and start a new one before messaging the user.
-
-By structuring sessions in this way, Open Chat Studio ensures privacy-conscious, context-aware, and seamless interactions across different communication channels.
+For task-focused setup instructions, see [How to reset sessions](../how-to/reset_sessions.md).

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -48,6 +48,8 @@ For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current 
 - The current session is marked as completed.
 - A new session is started with a fresh history.
 
+For a detailed breakdown of session states and transitions, see [Session Status](session_status.md).
+
 This means that, aside from participant data, the bot loses all information about the previous conversation — including the fact that it even took place.
 
 ### Manual resets

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -45,11 +45,11 @@ On the **Web** channel, users can have **anonymous sessions**, where:
 
 For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current session continues until it is explicitly ended. 
 
-However, sessions can be reset either [manually](../how-to/reset_sessions.md#reset-a-session-manually) by the user or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically). 
+However, sessions can be reset either [manually](../how-to/reset_sessions.md#user-initiated-manual-reset-of-a-session) by the user or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically). 
 
 When a session is reset:
 
-- The current session is marked as [completed](./session_status.md#complete).
+- The current session is marked as completed.
 - A new session is started with a fresh history.
 
 This means that, aside from participant data, the bot loses all information about the previous conversation — including the fact that it even took place.

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -37,7 +37,7 @@ These tools appear in your chatbot's node settings. Enable only the ones your ch
 - **[Get session state key](../../tech-hub/tools.md#get-session-state-key)** — Retrieves a value previously stored in session state during the current session.
 - **[Append to session state](../../tech-hub/tools.md#append-to-session-state)** — Adds a value to a list in the session state. Use this to track items within a single session — for example, a list of topics discussed so far. See [Sessions](../sessions.md) for more information.
 - **[Increment session state counter](../../tech-hub/tools.md#increment-session-state-counter)** — Increments a numeric counter stored in session state. Use this to count events within a single session.
-- **[End session](../../tech-hub/tools.md#end-session)** — Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete. See [Sessions](../sessions.md) for more information.
+- **[End session](../../tech-hub/tools.md#end-session)** — Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete. See [Sessions](../sessions.md) for more information and [Session Status](../session_status.md) for status transitions.
 
 
 ## LLM provider tools

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -1,0 +1,61 @@
+---
+title: How to reset sessions
+---
+
+# How to reset sessions
+
+Use this guide to end a current session and start a new one. Resets can be done manually or [automatically](#reset-sessions-automatically).
+
+## Before you begin
+
+- Confirm which [channel](../concepts/channels.md) your chatbot uses.
+- For **Web Chat Widget** and **Slack**, use the session reset button in the UI.
+- For messaging channels (such as WhatsApp and Telegram), use `/reset` or an automatic method.
+
+!!! note
+    Resetting a session ends the current conversation history. Participant data is not removed.
+
+## Reset a session manually
+
+**Users** can manually reset a session in two ways:
+
+### Reset manually from chat channel
+
+1. View the conversation in the chatbot channel
+2. Send `/reset`as a text command
+3. Continue chatting to start a fresh session.
+
+This command is available on channels except **Web Chat Widget** and **Slack**.
+
+### Reset manually from the web UI
+
+This button provides more control over the session reset process compared to the `/reset` command, allowing users to customize how the transition between sessions occurs.
+
+1. View the chat widget on the web interface.
+2. Click the session reset button.
+3. Choose whether to trigger [end conversation events](../concepts/events.md) or skip them
+4. Enter a chat message for the new session.
+
+If your chatbot has been configured with a seed message, this is pre-filled and then can be edited by the user.
+
+## Reset sessions automatically
+There are two ways to automatically reset a session:
+
+### Reset automatically with Events
+
+Use this when session resets should happen based on lifecycle conditions.
+
+- You can configure an event to end the current session when the event is triggered. This will not automatically create a new session; however, if the user sends a message after the session is ended, a new session will be created.
+- When this event fires, the current session ends. A new session starts when the participant sends the next message.
+- For more on event types and actions, see [Events](../concepts/events.md).
+
+### Reset automatically via API
+
+Use this when your integration controls when conversations should restart.
+
+ When using the [Trigger Bot Message](https://openchatstudio.com/api/docs/#tag/Channels/operation/trigger_bot_message) API, you can set `"start_new_session": true`, which will end the current session and start a new one before messaging the user.
+
+## Related concepts
+
+- [Chat Sessions](../concepts/sessions.md)
+- [Session Status](../concepts/session_status.md)

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -13,9 +13,9 @@ Use this guide to end a current [session](../concepts/sessions.md) and start a n
 - For messaging channels (such as WhatsApp and Telegram), use `/reset` or an automatic method.
 
 !!! note
-    Resetting a session ends the current conversation history. Participant data is not removed.
+    Resetting a session clears the conversation history — the bot will have no memory of previous exchanges. Participant data is not removed.
 
-## User-Initiated Manual Reset of a session
+## User-Initiated manual reset of a session
 
 ### Reset manually from chat channel
 
@@ -23,33 +23,27 @@ Use this guide to end a current [session](../concepts/sessions.md) and start a n
 2. Send `/reset` (case-insensitive) as a text command
 3. Continue chatting to start a fresh session.
 
-This command is available on channels except **Web Chat Widget** and **Slack**.
+This command is available on all channels except **Web Chat Widget** and **Slack**.
 
 ### Reset manually from the web UI
 
-The "New Chat" button provides more control over the session reset process compared to the `/reset` command, allowing users to customize how the transition between sessions occurs.
+This allows users to customize how the transition between sessions occurs.
 
-1. As a participant, view the chat widget on the web interface.
-2. Click the session reset button.
+1. As a participant, view the chat widget on the web chat interface.
+2. Click the "End chat" button.
 3. Choose whether to trigger [end conversation events](../concepts/events.md) or skip them
 4. Enter a chat message for the new session.
 
 If your chatbot has been configured with a seed message, this is pre-filled and then can be edited by the user.
 
-### Reset manually from the Admin UI
+### Reset manually from the OCS Admin UI
 
-When viewing the "Chatbot Review" screen, the "End Session" button ends the current session and creates a new one for the same participant and channel.
+When viewing the session detail, the "End Session" button ends the current session. 
+- For more on ending sessions see [Session Status](../concepts/session_status.md#pending_review)
 
 ## Reset sessions automatically
-There are two ways to automatically reset a session:
 
-### Reset automatically with Events
-
-Use this when session resets should happen based on lifecycle conditions.
-
-- You can configure an event to end the current session when the event is triggered. This will not automatically create a new session; however, if the user sends a message after the session is ended, a new session will be created.
-- When this event fires, the current session ends. A new session starts when the participant sends the next message.
-- For more on event types and actions, see [Events](../concepts/events.md).
+For details on how to end sessions from a chatbot see [Session Status](../concepts/session_status.md#ending-sessions-from-a-chatbot)
 
 ### Reset automatically via API
 
@@ -60,4 +54,4 @@ Use this when your integration controls when conversations should restart.
 ## Related concepts
 
 - [Chat Sessions](../concepts/sessions.md)
-- [Session Status](../concepts/session_status.md)
+- [Session Status](../concepts/session_status.md#pending_review)

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -4,7 +4,7 @@ title: How to reset sessions
 
 # How to reset sessions
 
-Use this guide to end a current session and start a new one. Resets can be done manually or [automatically](#reset-sessions-automatically).
+Use this guide to end a current [session](../concepts/sessions.md) and start a new one. Resets can be done [manually](#user-initiated-manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
 
 ## Before you begin
 
@@ -15,28 +15,30 @@ Use this guide to end a current session and start a new one. Resets can be done 
 !!! note
     Resetting a session ends the current conversation history. Participant data is not removed.
 
-## Reset a session manually
-
-**Users** can manually reset a session in two ways:
+## User-Initiated Manual Reset of a session
 
 ### Reset manually from chat channel
 
-1. View the conversation in the chatbot channel
-2. Send `/reset`as a text command
+1. As a participant, view the conversation in the chatbot channel
+2. Send `/reset` (case-insensitive) as a text command
 3. Continue chatting to start a fresh session.
 
 This command is available on channels except **Web Chat Widget** and **Slack**.
 
 ### Reset manually from the web UI
 
-This button provides more control over the session reset process compared to the `/reset` command, allowing users to customize how the transition between sessions occurs.
+The "New Chat" button provides more control over the session reset process compared to the `/reset` command, allowing users to customize how the transition between sessions occurs.
 
-1. View the chat widget on the web interface.
+1. As a participant, view the chat widget on the web interface.
 2. Click the session reset button.
 3. Choose whether to trigger [end conversation events](../concepts/events.md) or skip them
 4. Enter a chat message for the new session.
 
 If your chatbot has been configured with a seed message, this is pre-filled and then can be edited by the user.
+
+### Reset manually from the Admin UI
+
+When viewing the "Chatbot Review" screen, the "End Session" button ends the current session and creates a new one for the same participant and channel.
 
 ## Reset sessions automatically
 There are two ways to automatically reset a session:
@@ -53,7 +55,7 @@ Use this when session resets should happen based on lifecycle conditions.
 
 Use this when your integration controls when conversations should restart.
 
- When using the [Trigger Bot Message](https://openchatstudio.com/api/docs/#tag/Channels/operation/trigger_bot_message) API, you can set `"start_new_session": true`, which will end the current session and start a new one before messaging the user.
+ - When using the [Trigger Bot Message](https://openchatstudio.com/api/docs/#tag/Channels/operation/trigger_bot_message) API, you can set `"start_new_session": true`, which will end the current session and start a new one before messaging the user.
 
 ## Related concepts
 

--- a/docs/tech-hub/tools.md
+++ b/docs/tech-hub/tools.md
@@ -157,7 +157,7 @@ Increments a numeric counter stored in [session state](../concepts/sessions.md).
 
 ### End session
 
-Ends the current chat [session](../concepts/sessions.md). The session is marked as completed. New messages will start a fresh session.
+Ends the current chat [session](../concepts/sessions.md). The session is marked as completed. New messages will start a fresh session. See [Session Status](../concepts/session_status.md) for how statuses transition after ending a session.
 
 - Name: `end-session`
 - Arguments: (none)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,13 +107,13 @@ nav:
       - how-to/deploy_to_different_channels.md
       - Reset Sessions: how-to/reset_sessions.md
       - how-to/whatsapp_meta_cloud_api.md
-      - how-to/global_search.md
+      - Find Objects: how-to/global_search.md
       - Filter Tables with Natural Language: how-to/nl_filter.md
-      - Router Nodes:
+      - Configure Router Nodes:
         - how-to/routers/index.md
-        - how-to/routers/llm_router.md
+        - Configure LLM Router: how-to/routers/llm_router.md
         - how-to/routers/static_router.md
-      - how-to/setting_up_a_survey.md
+      - Setup a Survey: how-to/setting_up_a_survey.md
       - how-to/assistants_migration.md
       - FAQ: how-to/faq.md
   - Concepts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - how-to/workflow_cookbook.md
       - how-to/add_a_knowledge_base.md
       - how-to/deploy_to_different_channels.md
+      - Reset Sessions: how-to/reset_sessions.md
       - how-to/whatsapp_meta_cloud_api.md
       - how-to/global_search.md
       - Filter Tables with Natural Language: how-to/nl_filter.md


### PR DESCRIPTION
These changes initiated by a new page on Session Status which needed to be linked into other existing pages. 

This PR improves the docs around session resets by introducing a new "How to reset sessions" guide and simplifies the Chat Sessions Concept page

It clarifies how sessions can be reset manually or automatically, These changes make it easier for users to understand where and how a session can be reset. And reduces the complexity of the session concepts page

**Documentation improvements for session resets:**

* Added a new guide: `how-to/reset_sessions.md`, detailing how to reset sessions manually (via UI or chat command) or automatically (via events or API), and linked it from the navigation. 
* Updated `concepts/sessions.md` to refer users to the new "How to reset sessions" guide for step-by-step instructions.

**Session status and cross-referencing:**

* Added a definition for "Session Status" in `concepts/index.md` and referenced it in relevant documentation to clarify session lifecycle states.
* Updated references 


### Reviewer Notes
- there is some overlap between **ending** a session and **resetting** a session