### PR TITLE
add dependancy checking with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,9 @@ updates:
       interval: "weekly"
       day: "tuesday"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
+    open-pull-requests-limit: 5
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "tuesday"


### PR DESCRIPTION
When troubleshooting a GitHub action workflow, noticed that the workflows were on v4 where the other repos have actions/checkout@v6

This dependency checking will keep github-actions updated in the future
Also to keep uv updated

I will update version of actions in another PR as for testing the Issue https://github.com/dimagi/open-chat-studio-docs/issues/417 needs to have the latest libraries