### PR TITLE
New "Schedule Reminders" pg & note that scheduled msgs are viewed for participants

### DIFF
--- a/docs/concepts/participant_data.md
+++ b/docs/concepts/participant_data.md
@@ -2,13 +2,13 @@
 
 Participant data is custom information you store against a participant to personalize their experience. You can use it to remember preferences, track progress, or pass context into your chatbot's prompts.
 
-Each participant record is tied to a specific channel (such as WhatsApp or the web) and a specific chatbot. The same person using two different channels, or two different chatbots, will have separate participant records for each. OCS does not automatically merge these records.
+Each participant record is tied to a specific [channel](./channels.md) (such as WhatsApp or the web) and a specific chatbot. The same person using two different channels, or two different chatbots, will have separate participant records for each. OCS does not automatically merge these records.
 
 ## Managing participant records
 
-You can view and edit participant data on the Participant Details page. Open it by selecting a participant from the Participants list.
+You can view and edit participant data on the **Participant Details** page. Open it by selecting a participant from the Participants list. You can also export and import participant data from the Participants list page.
 
-You can also export and import participant data from the Participants list page.
+The **Session details** screen shows both the **participant's data** and their **participant schedules** — the [reminders](../how-to/reminders.md) and scheduled messages set for that participant — in one place. 
 
 To add a participant manually, use the Create action and provide an identifier, platform, and optional name. If a participant with that platform and identifier already exists for the team, the form links you to the existing record.
 

--- a/docs/concepts/participant_data.md
+++ b/docs/concepts/participant_data.md
@@ -8,7 +8,7 @@ Each participant record is tied to a specific [channel](./channels.md) (such as 
 
 You can view and edit participant data on the **Participant Details** page. Open it by selecting a participant from the Participants list. You can also export and import participant data from the Participants list page.
 
-The **Session details** screen shows both the **participant's data** and their **participant schedules** — the [reminders](../how-to/reminders.md) and scheduled messages set for that participant — in one place. 
+The **Session details** screen shows both the **Participant's Data** and their **participant Schedules** - the [reminders](../how-to/reminders.md) and scheduled messages set for that participant — in one place.
 
 To add a participant manually, use the Create action and provide an identifier, platform, and optional name. If a participant with that platform and identifier already exists for the team, the form links you to the existing record.
 
@@ -59,6 +59,6 @@ You can also update the participant data using the API. This is useful if you wa
 
 For the full details on using the API, see the [API docs](https://openchatstudio.com/api/docs/).
 
-## System properties
+## Participant Timezone for web channel
 
 The system automatically sets the `timezone` participant data property when a participant uses the web channel. It comes from the participant's browser and helps localize date and time values in prompts.

--- a/docs/concepts/participant_data.md
+++ b/docs/concepts/participant_data.md
@@ -8,7 +8,7 @@ Each participant record is tied to a specific [channel](./channels.md) (such as 
 
 You can view and edit participant data on the **Participant Details** page. Open it by selecting a participant from the Participants list. You can also export and import participant data from the Participants list page.
 
-The **Session details** screen shows both the **Participant's Data** and their **participant Schedules** - the [reminders](../how-to/reminders.md) and scheduled messages set for that participant — in one place.
+The **Session details** screen shows both the **Participant Data** and their **Participant Schedules** - the [reminders](../how-to/reminders.md) and scheduled messages set for that participant — in one place.
 
 To add a participant manually, use the Create action and provide an identifier, platform, and optional name. If a participant with that platform and identifier already exists for the team, the form links you to the existing record.
 

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -25,19 +25,36 @@ Tools in Open Chat Studio fall into two categories:
 
 These tools appear in your chatbot's node settings. Enable only the ones your chatbot needs.
 
-- **[Calculator](../../tech-hub/tools.md#calculator)** — Performs reliable mathematical calculations. Use this when your chatbot needs to compute values accurately rather than relying on the language model's estimation.
+### Reminders
+
+Schedule messages to be delivered to participants at a future time — even after the conversation has ended. See [Schedule Reminders](../../how-to/reminders.md) for a step-by-step guide.
+
 - **[Recurring reminders](../../tech-hub/tools.md#recurring-reminders)** — Schedules a repeating reminder for the participant — for example, a daily check-in message. You can set the start date, frequency, and an optional end date or maximum number of repetitions.
 - **[One-off reminder](../../tech-hub/tools.md#one-off-reminder)** — Schedules a single reminder message to be sent to the participant at a specific future date and time.
 - **[Delete reminder](../../tech-hub/tools.md#delete-reminder)** — Cancels an existing reminder (either a one-off or a recurring one). Use this when your chatbot should let participants cancel scheduled messages.
 - **[Move reminder date](../../tech-hub/tools.md#move-reminder-date)** — Changes the date or time of an existing reminder. Use this to let participants reschedule a reminder without deleting and recreating it.
-- **[Update participant data](../../tech-hub/tools.md#update-participant-data)** — Writes a value to a participant's stored data under a specific key. Use this when the chatbot should remember something about the participant across sessions, such as a preference or a recorded response. See [Participant Data](../participant_data.md) for more information.
-- **[Append to participant data](../../tech-hub/tools.md#append-to-participant-data)** — Adds a value to participant data at a specific key. Use this to track multiple items over time — for example, a list of topics a participant has mentioned. See [Participant Data](../participant_data.md) for more information.
-- **[Increment counter](../../tech-hub/tools.md#increment-counter)** — Increments a numeric counter stored in participant data. Use this to track how many times something has happened across sessions — for example, how many check-ins a participant has completed. See [Participant Data](../participant_data.md) for more information.
+
+### Participant data
+
+Store and update information about a participant that persists across sessions. See [Participant Data](../participant_data.md) for more information.
+
+- **[Update participant data](../../tech-hub/tools.md#update-participant-data)** — Writes a value to a participant's stored data under a specific key. Use this when the chatbot should remember something about the participant across sessions, such as a preference or a recorded response.
+- **[Append to participant data](../../tech-hub/tools.md#append-to-participant-data)** — Adds a value to participant data at a specific key. Use this to track multiple items over time — for example, a list of topics a participant has mentioned.
+- **[Increment counter](../../tech-hub/tools.md#increment-counter)** — Increments a numeric counter stored in participant data. Use this to track how many times something has happened across sessions — for example, how many check-ins a participant has completed.
+
+### Session
+
+Read and write data within the current session, or manage the session lifecycle. Data stored here is available only for the duration of the session. See [Sessions](../sessions.md) for more information.
+
 - **[Set session state key](../../tech-hub/tools.md#set-session-state-key)** — Stores a key-value pair in the session state, which persists for the duration of the current session. Useful in pipeline configurations where one part of the conversation needs to pass information to another.
 - **[Get session state key](../../tech-hub/tools.md#get-session-state-key)** — Retrieves a value previously stored in session state during the current session.
-- **[Append to session state](../../tech-hub/tools.md#append-to-session-state)** — Adds a value to a list in the session state. Use this to track items within a single session — for example, a list of topics discussed so far. See [Sessions](../sessions.md) for more information.
+- **[Append to session state](../../tech-hub/tools.md#append-to-session-state)** — Adds a value to a list in the session state. Use this to track items within a single session — for example, a list of topics discussed so far.
 - **[Increment session state counter](../../tech-hub/tools.md#increment-session-state-counter)** — Increments a numeric counter stored in session state. Use this to count events within a single session.
-- **[End session](../../tech-hub/tools.md#end-session)** — Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete. See [Sessions](../sessions.md) for more information and [Session Status](../session_status.md) for status transitions.
+- **[End session](../../tech-hub/tools.md#end-session)** — Marks the current session as complete. After this, any new message from the participant will begin a fresh session. Use this when the chatbot should formally close a conversation — for example, after a survey is complete. See [Session Status](../session_status.md) for status transitions.
+
+### Utilities
+
+- **[Calculator](../../tech-hub/tools.md#calculator)** — Performs reliable mathematical calculations. Use this when your chatbot needs to compute values accurately rather than relying on the language model's estimation.
 
 
 ## LLM provider tools

--- a/docs/how-to/reminders.md
+++ b/docs/how-to/reminders.md
@@ -1,0 +1,47 @@
+# Schedule Reminders
+
+Reminder tools let your chatbot schedule messages that OCS delivers to participants at a future time — even after the conversation ends. For an overview of the four tools, see [Reminders](../concepts/tools/index.md#reminders).
+
+## Prerequisites
+
+- An existing chatbot connected to at least one channel (WhatsApp, Telegram, web widget, etc.).
+
+## Step 1: Enable the reminder tools
+
+1. Open your chatbot's node settings.
+2. In the **Tools** section, enable the reminder tools your chatbot needs.
+
+!!! tip
+    Only enable what the chatbot needs — a shorter tool list helps the LLM stay focused.
+
+## Step 2: Guide the LLM in your system prompt
+
+Add instructions to your system prompt that name the tools explicitly:
+
+```
+When the participant asks to be reminded once, use the `one-off-reminder` tool.
+When the participant asks to be recurrently reminded about something, use the `recurring-reminder` tool.
+When they ask to cancel a reminder, use the `delete-reminder` tool.
+When they ask to change the time, use the `move-scheduled-message-date` tool.
+```
+
+Also describe the tone for reminder messages:
+
+```
+Write reminder messages in a warm, encouraging tone.
+For example: "Good morning! Time to take your medication."
+```
+
+## Step 3: Handle timezones
+
+Reminders are scheduled in UTC. Include the participant's timezone in your system prompt so the LLM converts times correctly:
+
+```
+Participants are in Cape Town, South Africa (UTC+2). Convert their requested local time to UTC when scheduling reminders.
+```
+
+## Step 4: Verify reminders for a participant
+
+To confirm a reminder was scheduled or troubleshoot a missed message, open the participant's chatbot **Session details** screen. It shows both the participant's data and their **participant schedules** — all active reminders and scheduled messages — in one place.
+
+See [Participant data](../concepts/participant_data.md) for details on how to use participant data.

--- a/docs/how-to/reminders.md
+++ b/docs/how-to/reminders.md
@@ -34,10 +34,15 @@ For example: "Good morning! Time to take your medication."
 
 ## Step 3: Handle timezones
 
-Reminders are scheduled in UTC. Include the participant's timezone in your system prompt so the LLM converts times correctly:
+The tools handle timezones differently:
+
+- `one-off-reminder` and `recurring-reminder` store ISO 8601 datetime strings, which can carry a timezone offset. The LLM does not need to convert to UTC for these tools.
+- `move-scheduled-message-date` takes an `hour` value in UTC. The LLM must convert the participant's local time to UTC when calling this tool.
+
+If the channel is the web chat widget, the participant's timezone is available as [participant data](../concepts/participant_data.md#participant-timezone-for-web-channel). For other channels, include the timezone in your system prompt:
 
 ```
-Participants are in Cape Town, South Africa (UTC+2). Convert their requested local time to UTC when scheduling reminders.
+Participants are in Cape Town, South Africa (UTC+2). When calling move-scheduled-message-date, convert their requested local time to UTC.
 ```
 
 ## Step 4: Verify reminders for a participant

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,8 @@ nav:
       - how-to/workflow_cookbook.md
       - how-to/add_a_knowledge_base.md
       - how-to/deploy_to_different_channels.md
+      - Setup a Survey: how-to/setting_up_a_survey.md
+      - Schedule Reminders: how-to/reminders.md
       - Reset Sessions: how-to/reset_sessions.md
       - how-to/whatsapp_meta_cloud_api.md
       - Find Objects: how-to/global_search.md
@@ -112,9 +114,7 @@ nav:
       - Configure Router Nodes:
         - how-to/routers/index.md
         - Configure LLM Router: how-to/routers/llm_router.md
-        - how-to/routers/static_router.md
-      - Setup a Survey: how-to/setting_up_a_survey.md
-      - Schedule Reminders: how-to/reminders.md
+        - Configure Static Router: how-to/routers/static_router.md
       - how-to/assistants_migration.md
       - FAQ: how-to/faq.md
   - Concepts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
         - Configure LLM Router: how-to/routers/llm_router.md
         - how-to/routers/static_router.md
       - Setup a Survey: how-to/setting_up_a_survey.md
+      - Schedule Reminders: how-to/reminders.md
       - how-to/assistants_migration.md
       - FAQ: how-to/faq.md
   - Concepts:


### PR DESCRIPTION
## Background

There is an issue to add to user docs that scheduled messages are stored on participant data.
Resolves: https://github.com/dimagi/open-chat-studio/issues/1141

### Changes made
Expands the docs for participant data and reminder tools. 

Instead of just adding info to the participant data page, I added a new step-by-step guide for scheduling reminders and then clarified how participant and reminders data is accessed. 
Giving context to the fact that scheduled messages are stored on participants.

Documentation improvements and new guide:

* Added a new "Schedule Reminders" how-to guide that provides step-by-step instructions for enabling and using reminder tools, including best practices for prompt engineering and handling timezones.

Reorganization of tools list:

* Reorganized the tools `docs/concepts/tools/index.md` into thematic sections (Reminders, Participant data, Session, Utilities) so can link to this easily from "Schedule Reminders" how-to guide
