### PR TITLE
Fix User Doc automation GitHub workflow & tech debt

### DIFF
--- a/.github/templates/changelog-instructions.md
+++ b/.github/templates/changelog-instructions.md
@@ -5,6 +5,7 @@ You need to update the changelog and documentation in this repository based on a
 - **PR Title:** ${PR_TITLE}
 - **PR URL:** ${PR_URL}
 - **Author:** ${PR_AUTHOR}
+
 ## PR Description
 ```
 ${PR_BODY}
@@ -36,11 +37,12 @@ ${CHANGELOG_INSTRUCTIONS}
 After updating the changelog, analyze whether this PR requires documentation updates:
 
 1. **Check if documentation is needed:**
-   - New features → Need user guides, how-tos, or concept docs
-   - API changes → Update API documentation
-   - Configuration changes → Update setup/configuration docs
+   - New feature → Need concept and/or how-tos
+   - UI changes and/or a Demo → Update user guides or how-tos
+   - Configuration changes → Update setup/configuration docs in tech hub
    - Behavior changes → Update relevant user guides
-   - Bug fixes → Usually no docs needed unless it changes behavior
+   - API changes → Update API documentation
+   - Bug fixes → Usually no docs needed unless it changes behavior/UI or screens/views
    - Internal/refactoring → Skip documentation updates
 
 2. **If documentation IS needed:**

--- a/.github/templates/changelog-instructions.md
+++ b/.github/templates/changelog-instructions.md
@@ -5,9 +5,6 @@ You need to update the changelog and documentation in this repository based on a
 - **PR Title:** ${PR_TITLE}
 - **PR URL:** ${PR_URL}
 - **Author:** ${PR_AUTHOR}
-- **Is Widget Change:** ${IS_WIDGET_CHANGE}
-- **Base Branch:** ${BASE_BRANCH}
-
 ## PR Description
 ```
 ${PR_BODY}

--- a/.github/templates/changelog-instructions.md
+++ b/.github/templates/changelog-instructions.md
@@ -5,8 +5,6 @@ You need to update the changelog and documentation in this repository based on a
 - **PR Title:** ${PR_TITLE}
 - **PR URL:** ${PR_URL}
 - **Author:** ${PR_AUTHOR}
-- **Merged Date:** ${PR_MERGED_AT}
-- **Labels:** ${PR_LABELS}
 - **Is Widget Change:** ${IS_WIDGET_CHANGE}
 - **Base Branch:** ${BASE_BRANCH}
 

--- a/.github/templates/main-changelog-section.md
+++ b/.github/templates/main-changelog-section.md
@@ -19,7 +19,6 @@ Since this PR modifies main app files, update the **main changelog** at `${MAIN_
 5. Use today's date formatted as "MMM D, YYYY" with no leading zero on single-digit days (e.g., "Oct 9, 2025", "Oct 22, 2025")
 6. **Date sections must be in reverse chronological order (newest dates at the top)**
 7. If a section for that date already exists, add your entry to it; otherwise create a new date section at the top
-8. If a section for that date already exists, add your entry to it; otherwise create a new date section at the top
 
 **Main Changelog Format:**
 ```markdown

--- a/.github/templates/main-changelog-section.md
+++ b/.github/templates/main-changelog-section.md
@@ -16,7 +16,7 @@ Since this PR modifies main app files, update the **main changelog** at `${MAIN_
    - **BUG**: Bug fixes
    - **MIGRATION**: Migration-related changes or breaking changes
 4. Write a clear, concise changelog entry (1-2 sentences max)
-5. Format the merged date as "MMM D, YYYY" with no leading zero on single-digit days (e.g., "Oct 9, 2025", "Oct 22, 2025")
+5. Use today's date formatted as "MMM D, YYYY" with no leading zero on single-digit days (e.g., "Oct 9, 2025", "Oct 22, 2025")
 6. **Date sections must be in reverse chronological order (newest dates at the top)**
 7. If a section for that date already exists, add your entry to it; otherwise create a new date section at the top
 8. If a section for that date already exists, add your entry to it; otherwise create a new date section at the top

--- a/.github/workflows/README-changelog-automation.md
+++ b/.github/workflows/README-changelog-automation.md
@@ -2,17 +2,16 @@
 
 This process keeps user-facing documentation and changelog entries aligned after PRs are merged in the main product repository.
 
+
+This page is for maintainers of this process. It explains how the system is organized, where to make updates and troubleshooting
+
 Workflows in this repository and in the [OCS repository](https://github.com/dimagi/open-chat-studio/tree/main/.github/workflows) work together. The source workflow sends PR context to this docs repository, Claude updates changelog and docs when needed, and a docs PR is opened only when there is a meaningful content change.
-
-This page is for maintainers of the changelog automation process. It explains how the system is organized and where to make updates.
-
-For broader process guidance and details about main app vs chat widget, see the [developer guide](https://developers.openchatstudio.com/developer_guides/user_docs/).
 
 ## Maintenance Notes
 
 Use this map to decide where to make updates:
 
-- `.github/templates/`: Change automation decisions, such as when changelog or docs updates are required.
+- `.github/templates/`: 1) Changelog section templates and 2) Instruction file for **decisions** on if changelog or docs updates are required.
 - `.claude/agents/`: Change writing and review standards used by Claude.
 - `.claude/commands/`: Change reusable command workflows.
 
@@ -33,7 +32,8 @@ Troubleshooting and process changes can involve both repositories:
 
 ## Troubleshooting
 
-- **Manual Trigger:** To run the workflow manually, open GitHub Actions, select `Update Changelog and Docs from OCS PR`, and enter the OCS PR number.
+- **Manual Trigger:** To test, run the workflow manually, open GitHub Actions, select `Update Changelog and Docs from OCS PR`, and enter the OCS PR number. There is no risk to rerunning this for a PR. 
+    - Note: workflows will fail if running from a fork
 - **No PR created:** Check workflow runs in both repositories. If there was no meaningful docs/changelog change, no docs PR is expected.
 - **Unexpected target branch or classification:** Check workflow logs in the source and receiving repos to verify how the PR was classified.
 - **Authentication or permission failures:** Verify `OCS_DOCS_PAT` and `ANTHROPIC_API_KEY` are set correctly and still valid.
@@ -43,7 +43,7 @@ Troubleshooting and process changes can involve both repositories:
 
 ## Best Practices
 
-1. [Contribution Guides for Creating Good PRs](https://developers.openchatstudio.com/contributing/pull_requests/)
-2. [User docs and changelog process](https://developers.openchatstudio.com/developer_guides/user_docs/)
-3. [Claude custom Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
+1. [User docs and changelog process](https://developers.openchatstudio.com/developer_guides/user_docs/)
+2. [Developer guide with details on the main app vs chat widget](https://developers.openchatstudio.com/developer_guides/user_docs/).
+3. [Background to using Claude custom Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -190,8 +190,6 @@ jobs:
           export PR_NUMBER="${{ steps.set_vars.outputs.pr_number }}"
           export PR_URL="${{ steps.set_vars.outputs.pr_url }}"
           export PR_AUTHOR="${{ steps.set_vars.outputs.pr_author }}"
-          export IS_WIDGET_CHANGE="${{ steps.set_vars.outputs.is_widget_change }}"
-          export BASE_BRANCH="${{ steps.set_vars.outputs.base_branch }}"
           export WIDGET_CHANGELOG="${{ env.WIDGET_CHANGELOG }}"
           export MAIN_CHANGELOG="${{ env.MAIN_CHANGELOG }}"
           export WIDGET_PATH_PREFIX="${{ env.WIDGET_PATH_PREFIX }}"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -91,6 +91,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # When this workflow is triggered manually (workflow_dispatch) from a feature branch,
+      # the checkout step above always checks out main/widget-develop — meaning any template
+      # changes on the triggering branch would be silently ignored. This step overlays
+      # .github/templates/ from the triggering branch so that template edits can be tested
+      # end-to-end without merging to main first. It is a no-op for main/widget-develop
+      # and skipped entirely for repository_dispatch (production) runs.
+      - name: Override templates from triggering branch (workflow_dispatch testing)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          WORKFLOW_BRANCH="${{ github.ref_name }}"
+          if [ "$WORKFLOW_BRANCH" != "main" ] && [ "$WORKFLOW_BRANCH" != "widget-develop" ]; then
+            echo "Fetching templates from branch: $WORKFLOW_BRANCH"
+            git fetch origin "$WORKFLOW_BRANCH"
+            git checkout "origin/$WORKFLOW_BRANCH" -- .github/templates/
+            echo "Templates overridden from $WORKFLOW_BRANCH"
+          fi
+
       - name: Set variables from dispatch or manual input
         id: set_vars
         # Payload fields are passed via env (not ${{ }} interpolation in the script body)

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -133,6 +133,7 @@ jobs:
               echo "$PAYLOAD_PR_BODY"
               echo "OCS_DOCS_EOF"
             } >> $GITHUB_OUTPUT
+
           else
             echo "pr_number=$INPUT_PR_NUMBER" >> $GITHUB_OUTPUT
             # Fetch PR details using GitHub API
@@ -189,7 +190,6 @@ jobs:
           export PR_NUMBER="${{ steps.set_vars.outputs.pr_number }}"
           export PR_URL="${{ steps.set_vars.outputs.pr_url }}"
           export PR_AUTHOR="${{ steps.set_vars.outputs.pr_author }}"
-          export PR_MERGED_AT="${{ steps.set_vars.outputs.pr_merged_at }}"
           export IS_WIDGET_CHANGE="${{ steps.set_vars.outputs.is_widget_change }}"
           export BASE_BRANCH="${{ steps.set_vars.outputs.base_branch }}"
           export WIDGET_CHANGELOG="${{ env.WIDGET_CHANGELOG }}"
@@ -202,12 +202,6 @@ jobs:
           EOF
           )
           export PR_TITLE
-
-          PR_LABELS=$(cat <<'EOF'
-          ${{ steps.set_vars.outputs.pr_labels }}
-          EOF
-          )
-          export PR_LABELS
 
           PR_BODY=$(cat <<'EOF'
           ${{ steps.set_vars.outputs.pr_body }}


### PR DESCRIPTION
### Problem 

Resolves bug [417 ](https://github.com/dimagi/open-chat-studio-docs/issues/417) where the a UI facing code change did not result in User document changes. An issue with Claude deciding that no changes were needed. 

### Background to workflow

In short: source PR merged -> workflow gathers PR metadata -> decides target branch/file paths -> runs AI-assisted changelog/docs update -> pushes branch -> opens docs PR -> posts summary/failure notice.

### Changes made

**Reduce DUPLICATION**

1. Removed IS_WIDGET_CHANGE and BASE_BRANCH from the 'changelog-instructions' template and their two export lines from the create_instructions step of workflow as these are determined in step 1 of the update-changelog workflow
2. Duplicate step in main-changelog-section.md Steps 7 and 8 are word-for-word identical

**Tech Debt: GitHub fields not sent from Dispatch workflow**

1. Both PR_MERGED_AT and PR_LABELS had been removed a while ago from the dispatch

**Dont need PR merge date & labels**

1. update-changelog.yml — removed PAYLOAD_PR_MERGED_AT env var as not used
2. changelog-instructions.md — removed the Merged Date, labels, is widget and base branch lines. Not needed as these are in the context Claude receives 
3. main-changelog-section.md — updated step 5 to tell Claude to use today's date rather than formatting a passed-in merged date



**README**

- Enhanced for troubleshooting