### PR TITLE
Clean up Changelog automation workflow

### DIFF
--- a/.github/templates/changelog-instructions.md
+++ b/.github/templates/changelog-instructions.md
@@ -6,7 +6,6 @@ You need to update the changelog and documentation in this repository based on a
 - **PR URL:** ${PR_URL}
 - **Author:** ${PR_AUTHOR}
 - **Merged Date:** ${PR_MERGED_AT}
-- **Labels:** ${PR_LABELS}
 - **Is Widget Change:** ${IS_WIDGET_CHANGE}
 - **Base Branch:** ${BASE_BRANCH}
 

--- a/.github/templates/main-changelog-section.md
+++ b/.github/templates/main-changelog-section.md
@@ -9,7 +9,7 @@ Since this PR modifies main app files, update the **main changelog** at `${MAIN_
 
 **Steps for Main Changelog:**
 1. Read `${MAIN_CHANGELOG}` to understand the current structure
-2. Analyze the PR title, description, and labels to understand what changed
+2. Analyze the PR title and description to understand what changed
 3. Determine the appropriate changelog type:
    - **NEW**: New features or functionality
    - **CHANGE**: Modifications to existing features

--- a/.github/templates/main-changelog-section.md
+++ b/.github/templates/main-changelog-section.md
@@ -19,7 +19,6 @@ Since this PR modifies main app files, update the **main changelog** at `${MAIN_
 5. Format the merged date as "MMM D, YYYY" with no leading zero on single-digit days (e.g., "Oct 9, 2025", "Oct 22, 2025")
 6. **Date sections must be in reverse chronological order (newest dates at the top)**
 7. If a section for that date already exists, add your entry to it; otherwise create a new date section at the top
-8. If a section for that date already exists, add your entry to it; otherwise create a new date section at the top
 
 **Main Changelog Format:**
 ```markdown

--- a/.github/workflows/README-changelog-automation.md
+++ b/.github/workflows/README-changelog-automation.md
@@ -2,16 +2,16 @@
 
 This process keeps user-facing documentation and changelog entries aligned after PRs are merged in the main product repository.
 
-This page is for maintainers of this process. It explains how the workflow is organized, where to make updates, and how to troubleshoot issues.
-
 Workflows in this docs repository and in the [OCS repository](https://github.com/dimagi/open-chat-studio/tree/main/.github/workflows) work together. The source workflow sends PR context to this docs repository, Claude updates changelog and docs when needed, and a docs PR is opened only when there is a meaningful content change.
+
+This page is for maintainers of this [process](https://developers.openchatstudio.com/developer_guides/user_docs/). It explains how the workflow is organized, where to make updates, and how to troubleshoot issues.
 
 ## Maintenance Notes
 
 Use this map to decide where to make updates:
 
-- `.github/templates/`: Changelog section templates and the full Claude instruction spec (`changelog-instructions.md`) — this file controls what Claude does across all three tasks: updating the changelog, deciding on and writing docs, and committing.
-- `.claude/agents/`: Writing and review standards used by Claude. The `zensical-technical-writer` agent handles all documentation writing decisions for this workflow.
+- `.github/templates/`: Changelog section templates and the (`changelog-instructions.md`) which is the top-level instruction spec Claude receives — it orchestrates all three tasks, delegating documentation writing to the zensical-technical-writer agent.
+- `.claude/agents/`: Writing and PR review standards used by Claude. The `zensical-technical-writer` agent handles all documentation writing decisions for this workflow.
 
 > **Note on `.claude/commands/`:** The `/write-docs` slash command is a human-facing shortcut for interactive Claude Code sessions — it simply invokes the same `zensical-technical-writer` agent. The automated workflow calls the agent directly via the `Task` tool and does not use slash commands.
 
@@ -31,7 +31,7 @@ Troubleshooting and process changes can involve both repositories:
 
 ## Troubleshooting
 
-- **Manual Trigger:** To test, run the workflow manually in GitHub Actions, select `Update Changelog and Docs from OCS PR`, and enter the OCS PR number. It is safe to rerun this for a PR.
+- **Manual Trigger:** To run the workflow manually: open GitHub Actions, select `Update Changelog and Docs from OCS PR`, and enter the OCS PR number. It is safe to rerun this for a PR.
     - Note: this workflow requires repository secrets and will fail in forks unless those secrets are configured.
 - **No PR created:** Check workflow runs in both repositories. If there was no meaningful docs/changelog change, no docs PR is expected.
 - **Unexpected target branch or classification:** Check workflow logs in the source and receiving repos to verify how the PR was classified.

--- a/.github/workflows/README-changelog-automation.md
+++ b/.github/workflows/README-changelog-automation.md
@@ -10,13 +10,12 @@ Workflows in this docs repository and in the [OCS repository](https://github.com
 
 Use this map to decide where to make updates:
 
-- `.github/templates/`: 1) Changelog section templates and 2) instruction files for **decisions** on whether changelog or docs updates are required.
-- `.claude/agents/`: Change writing and review standards used by Claude.
-- `.claude/commands/`: Change reusable command workflows.
+- `.github/templates/`: Changelog section templates and the full Claude instruction spec (`changelog-instructions.md`) — this file controls what Claude does across all three tasks: updating the changelog, deciding on and writing docs, and committing.
+- `.claude/agents/`: Writing and review standards used by Claude. The `zensical-technical-writer` agent handles all documentation writing decisions for this workflow.
+
+> **Note on `.claude/commands/`:** The `/write-docs` slash command is a human-facing shortcut for interactive Claude Code sessions — it simply invokes the same `zensical-technical-writer` agent. The automated workflow calls the agent directly via the `Task` tool and does not use slash commands.
 
 Keep in mind that behavior changes may require updates in both `.github/templates/` and `.claude/`.
-
-Use AI assistants to understand key files and their responsibilities when maintaining this workflow.
 
 ### Repositories in Scope
 
@@ -43,7 +42,6 @@ Troubleshooting and process changes can involve both repositories:
 
 ## Best Practices
 
-1. [User docs and changelog process](https://developers.openchatstudio.com/developer_guides/user_docs/)
-2. [Developer guide on docs branching and app/widget release flow](https://developers.openchatstudio.com/developer_guides/user_docs/)
-3. [Background to using Claude custom Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
+1. [Developer guide on docs branching and app/widget release flow](https://developers.openchatstudio.com/developer_guides/user_docs/)
+2. [Background to using Claude custom Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
 

--- a/.github/workflows/README-changelog-automation.md
+++ b/.github/workflows/README-changelog-automation.md
@@ -1,23 +1,22 @@
-# Changelog and Documentation Automation with Claude
+# Changelog and User Doc Automation with Claude
 
 This process keeps user-facing documentation and changelog entries aligned after PRs are merged in the main product repository.
 
-Workflows in this repository and in the [OCS repository](https://github.com/dimagi/open-chat-studio/tree/main/.github/workflows) work together. The source workflow sends PR context to this docs repository, Claude updates changelog and docs when needed, and a docs PR is opened only when there is a meaningful content change.
+This page is for maintainers of this process. It explains how the workflow is organized, where to make updates, and how to troubleshoot issues.
 
-This page is for maintainers of the changelog automation process. It explains how the system is organized and where to make updates.
-
-For broader process guidance and details about main app vs chat widget, see the [developer guide](https://developers.openchatstudio.com/developer_guides/user_docs/).
+Workflows in this docs repository and in the [OCS repository](https://github.com/dimagi/open-chat-studio/tree/main/.github/workflows) work together. The source workflow sends PR context to this docs repository, Claude updates changelog and docs when needed, and a docs PR is opened only when there is a meaningful content change.
 
 ## Maintenance Notes
 
 Use this map to decide where to make updates:
 
-- `.github/templates/`: Change automation decisions, such as when changelog or docs updates are required.
+- `.github/templates/`: 1) Changelog section templates and 2) instruction files for **decisions** on whether changelog or docs updates are required.
 - `.claude/agents/`: Change writing and review standards used by Claude.
 - `.claude/commands/`: Change reusable command workflows.
 
 Keep in mind that behavior changes may require updates in both `.github/templates/` and `.claude/`.
-Use AI assistants to understand key files and their responsibilities.
+
+Use AI assistants to understand key files and their responsibilities when maintaining this workflow.
 
 ### Repositories in Scope
 
@@ -33,17 +32,18 @@ Troubleshooting and process changes can involve both repositories:
 
 ## Troubleshooting
 
-- **Manual Trigger:** To run the workflow manually, open GitHub Actions, select `Update Changelog and Docs from OCS PR`, and enter the OCS PR number.
+- **Manual Trigger:** To test, run the workflow manually in GitHub Actions, select `Update Changelog and Docs from OCS PR`, and enter the OCS PR number. It is safe to rerun this for a PR.
+    - Note: this workflow requires repository secrets and will fail in forks unless those secrets are configured.
 - **No PR created:** Check workflow runs in both repositories. If there was no meaningful docs/changelog change, no docs PR is expected.
 - **Unexpected target branch or classification:** Check workflow logs in the source and receiving repos to verify how the PR was classified.
 - **Authentication or permission failures:** Verify `OCS_DOCS_PAT` and `ANTHROPIC_API_KEY` are set correctly and still valid.
 - **widget-develop branch doesn't exist:** Create it: `git checkout -b widget-develop main && git push origin widget-develop`
 - **Output quality needs improvement:** Comment on the generated PR with `@claude` and specify what to revise.
-- **For systemic quality issues:** Update the relevant agent in agents rather than correcting each PR manually.
+- **For systemic quality issues:** Update the relevant agent in `.claude/agents/` rather than correcting each PR manually.
 
 ## Best Practices
 
-1. [Contribution Guides for Creating Good PRs](https://developers.openchatstudio.com/contributing/pull_requests/)
-2. [User docs and changelog process](https://developers.openchatstudio.com/developer_guides/user_docs/)
-3. [Claude custom Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
+1. [User docs and changelog process](https://developers.openchatstudio.com/developer_guides/user_docs/)
+2. [Developer guide on docs branching and app/widget release flow](https://developers.openchatstudio.com/developer_guides/user_docs/)
+3. [Background to using Claude custom Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -203,12 +203,6 @@ jobs:
           )
           export PR_TITLE
 
-          PR_LABELS=$(cat <<'EOF'
-          ${{ steps.set_vars.outputs.pr_labels }}
-          EOF
-          )
-          export PR_LABELS
-
           PR_BODY=$(cat <<'EOF'
           ${{ steps.set_vars.outputs.pr_body }}
           EOF


### PR DESCRIPTION
### Problem 

While working on [417 ](https://github.com/dimagi/open-chat-studio-docs/issues/417) , noticed some clean up that was needed on this Workflow

### Background to workflow

In short: source PR merged -> workflow gathers PR metadata -> decides target branch/file paths -> runs AI-assisted changelog/docs update -> pushes branch -> opens docs PR -> posts summary/failure notice.

### Changes made

**Reduce duplication**

1. Duplicate step in main-changelog-section.md Steps 7 and 8 are word-for-word identical

**Tech Debt: GitHub fields not sent from Dispatch workflow**

1. Both PR_MERGED_AT and PR_LABELS had been removed a while ago from the dispatch
2. ONLY removed the PR_LABELS field from workflow
3. Removing PR_MERGED_AT is more complicated and I am not sure adds enough value

**README**

- Enhanced for troubleshooting



### Notes for reviewer

1. The PR_MERGED_AT is not sent via the dispatch workflow as it was removed a while ago. This causes a bit of confusion even though it does not break anything. The merged at date **is available** if run manually but not if automatically dispatched. Consider adding it back in the dispatch workflow
