### PR TITLE
Fix update-api-docs workflow: schema dir is api-schemas (plural)

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Fetch OpenAPI schema directory
         env:
           # Path to the per-version schema directory in the OCS repo.
-          # Change this one line once OCS finalizes the location.
-          API_SCHEMA_DIR: api-schema
+          API_SCHEMA_DIR: api-schemas
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- The daily `update-api-docs` cron was failing in the **Fetch OpenAPI schema directory** step with `gh: Not Found (HTTP 404)`.
- `API_SCHEMA_DIR` was set to the placeholder `api-schema` from PR #444; OCS has since published the directory as [`api-schemas`](https://github.com/dimagi/open-chat-studio/tree/main/api-schemas) (plural, contains `v1.yml`).
- One-line fix updating the env var to the real path.

## Verification
- `gh api repos/dimagi/open-chat-studio/contents/api-schemas?ref=main` returns `v1.yml`, matching the workflow's `\.ya?ml$` filter.
- Ran the fetch + `openapi_to_docs.py` steps locally against `docs/api/` — generation succeeds and produces no diff (docs already in sync with the upstream schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)