### PR TITLE
Clarify widget deprecation sunset and make badge theme-aware

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -17,12 +17,26 @@ open-chat-studio-widget {
     color: red;
 }
 
-/* Deprecated changelog versions: muted heading + badge with muted-orange icon */
+/* Deprecated changelog versions: muted heading + badge with muted-orange icon.
+   Markup contract: the badge paragraph must immediately follow the `.deprecated`
+   heading (the `+ p` sibling selector). Muting the heading and badge but leaving
+   the entry's bullet list at full contrast is intentional. */
 .deprecated,
 .deprecated + p {
     color: var(--md-default-fg-color--light);
 }
 
 .deprecated + p .twemoji {
-    color: #c77d3a;
+    color: var(--deprecated-icon-color);
+}
+
+/* Theme-aware deprecation icon: muted orange on light, brighter on the slate
+   (dark) scheme so it keeps adequate contrast. */
+:root,
+[data-md-color-scheme="default"] {
+    --deprecated-icon-color: #c77d3a;
+}
+
+[data-md-color-scheme="slate"] {
+    --deprecated-icon-color: #e5944a;
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ hide:
 ---
 
 # Changelog
+
+!!! info
+
+    Looking for the embeddable chat widget? See the [Chat Widget changelog](chat_widget/changelog.md).
+
 ## Jun 9, 2026
 * **NEW** Added a read-only v2 chatbots API: `GET /api/v2/chatbots/` (list) and `/{id}/` (retrieve), plus `/{id}/inspect/?version=`, which returns a single denormalized view of a chatbot's full configuration — settings, channels, pipeline nodes with their resources inlined, and event triggers. The response is self-documenting via the OpenAPI schema, making it well suited to LLM-agent consumers.
 * **BUG** Fixed an error when opening a chatbot's home page via a URL pointing to a version snapshot of the chatbot. Users are now redirected to the canonical URL of the active version instead of hitting an error.

--- a/docs/chat_widget/changelog.md
+++ b/docs/chat_widget/changelog.md
@@ -24,10 +24,9 @@ Check your current HTML implementation and compare it with the [latest propertie
 
 !!! warning "About deprecated versions"
 
-    Versions marked :octicons-alert-16: **Deprecated** are scheduled for removal on the
-    sunset date shown on each entry. After that date these versions stop receiving fixes
-    and their CDN builds may be removed. Upgrade to a supported version to stay current —
-    see the [Quick Upgrade Steps](#quick-upgrade-steps) above.
+    Versions marked :octicons-alert-16: **Deprecated** are no longer supported after the
+    sunset date shown on each entry, and may stop working. Upgrade to a supported version
+    to stay current — see the [Quick Upgrade Steps](#quick-upgrade-steps) above.
 
 ### v0.8.0 (2026-06-05)
 

--- a/docs/chat_widget/changelog.md
+++ b/docs/chat_widget/changelog.md
@@ -22,6 +22,12 @@ Check your current HTML implementation and compare it with the [latest propertie
 
 ## Changelog
 
+!!! warning "About deprecated versions"
+
+    Versions marked :octicons-alert-16: **Deprecated** reach their sunset date on
+    **2026-10-01**. After that date these versions stop receiving fixes and their CDN
+    builds may be removed. Upgrade to [v0.6.0+](#v060-2026-01-27) to stay supported.
+
 ### v0.8.0 (2026-06-05)
 
 * Add a `session-id` parameter to resume an existing chat session. (Used internally within the Open Chat Studio platform.)

--- a/docs/chat_widget/changelog.md
+++ b/docs/chat_widget/changelog.md
@@ -24,9 +24,10 @@ Check your current HTML implementation and compare it with the [latest propertie
 
 !!! warning "About deprecated versions"
 
-    Versions marked :octicons-alert-16: **Deprecated** reach their sunset date on
-    **2026-10-01**. After that date these versions stop receiving fixes and their CDN
-    builds may be removed. Upgrade to [v0.6.0+](#v060-2026-01-27) to stay supported.
+    Versions marked :octicons-alert-16: **Deprecated** are scheduled for removal on the
+    sunset date shown on each entry. After that date these versions stop receiving fixes
+    and their CDN builds may be removed. Upgrade to a supported version to stay current —
+    see the [Quick Upgrade Steps](#quick-upgrade-steps) above.
 
 ### v0.8.0 (2026-06-05)
 


### PR DESCRIPTION
Follow-up to #472, addressing the retrospective review.

- Adds a generic note at the top of the widget changelog explaining what a **Deprecated** badge means (no longer supported after the per-entry sunset date, may stop working). Worded so it doesn't need editing as new versions are deprecated.
- Makes the deprecation icon theme-aware via a custom property so it keeps contrast on the slate (dark) scheme, and documents the `.deprecated + p` markup contract in `extra.css`.
- Cross-links the main changelog to the widget changelog.

Skipped the review's suggestion to link all 13 badges individually — the single top-of-page note covers it without the noise.