### PR TITLE
Update chat widget latest version to 0.8.0

### DIFF
--- a/docs/chat_widget/index.md
+++ b/docs/chat_widget/index.md
@@ -26,7 +26,7 @@ Before embedding, you must create a bot in Open Chat Studio.
 1. Add the widget script to your site's `<head>` section:
    
       ```html
-      <script type='module' src='https://unpkg.com/open-chat-studio-widget@0.7.0/dist/open-chat-studio-widget/open-chat-studio-widget.esm.js' async></script>
+      <script type='module' src='https://unpkg.com/open-chat-studio-widget@0.8.0/dist/open-chat-studio-widget/open-chat-studio-widget.esm.js' async></script>
       ```
 
 2. Getting the Embed Code


### PR DESCRIPTION
Bump the embed script version in the widget getting-started guide from 0.7.0 to 0.8.0. The changelog already documents the v0.8.0 release.

Closes #481