### PR TITLE
fix: append incoming_message to Meta Cloud API webhook URL

### DIFF
--- a/docs/how-to/whatsapp_meta_cloud_api.md
+++ b/docs/how-to/whatsapp_meta_cloud_api.md
@@ -224,7 +224,7 @@ To update the language code:
 Open Chat Studio uses a **single global webhook endpoint** for all Meta Cloud API channels:
 
 ```
-https://openchatstudio.com/api/channels/meta/
+https://openchatstudio.com/api/channels/meta/incoming_message
 ```
 
 !!! info "Global endpoint"
@@ -239,7 +239,7 @@ To configure the webhook:
 
     | Field | Value |
     |---|---|
-    | Callback URL | `https://openchatstudio.com/api/channels/meta/` |
+    | Callback URL | `https://openchatstudio.com/api/channels/meta/incoming_message` |
     | Verify Token | The `Webhook Verify Token` you created in Step 3 |
 
 5. Click **Verify and Save**. Meta will send a verification request to OCS to confirm the token matches.
@@ -252,7 +252,7 @@ To configure the webhook:
     If the verification step fails, double-check that the `Webhook Verify Token` in the Meta portal exactly matches the value saved in your OCS provider configuration.
 
 !!! warning "Self-hosted instances"
-    If you are running a self-hosted instance of Open Chat Studio, replace `https://openchatstudio.com` with your own domain. The path `/api/channels/meta/` remains the same.
+    If you are running a self-hosted instance of Open Chat Studio, replace `https://openchatstudio.com` with your own domain. The path `/api/channels/meta/incoming_message` remains the same.
 
 ---
 


### PR DESCRIPTION
## Summary

Corrects the Meta Cloud API webhook URL in the "Configure the Webhook in Your Meta App" section of the WhatsApp Meta Cloud API guide. The endpoint should be `.../api/channels/meta/incoming_message`, not `.../api/channels/meta/`.

Updated all three references in the section:
- The global webhook endpoint code block
- The Callback URL table value
- The self-hosted path note

## Test plan

- [x] `git diff` confirms only the intended URL changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)