### PR TITLE
Fix update-api-docs crash on optional security requirement

### DIFF
--- a/scripts/tests/test_openapi_to_docs.py
+++ b/scripts/tests/test_openapi_to_docs.py
@@ -156,6 +156,30 @@ def test_inject_versions_list_reversed_markers_raises(tmp_path):
         inject_versions_list(index_path, ["v1"])
 
 
+def test_endpoint_security_handles_optional_requirement():
+    # An empty requirement object ({}) means auth is optional; it must not crash.
+    schema = {
+        "openapi": "3.0.0",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/api/me/": {
+                "get": {
+                    "tags": ["Me"],
+                    "summary": "Current user",
+                    "security": [{}, {"apiKeyAuth": []}, {"tokenAuth": ["read"]}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    converter = OpenAPIToMarkdownConverter(schema)
+    doc = converter._generate_tag_documentation("Me", converter._group_endpoints_by_tag()["Me"])
+
+    assert "(optional - no authentication required)" in doc
+    assert "apiKeyAuth" in doc
+    assert "Required scopes: read" in doc
+
+
 def test_convert_versioned_docs_end_to_end(tmp_path):
     # Schema directory with a single version
     schema_dir = tmp_path / "schemas"

--- a/src/ocs_docs/openapi_to_docs.py
+++ b/src/ocs_docs/openapi_to_docs.py
@@ -398,14 +398,17 @@ class OpenAPIToMarkdownConverter:
                         lines.append(f"      Schema: {schema_ref}")
 
         # Security
-        if security :=  operation.get("security", []):
+        if requirements := operation.get("security", []):
             lines.append("  Security:")
-            for security in security:
-                key = next(iter(security))
+            for requirement in requirements:
+                # An empty requirement object ({}) means authentication is optional.
+                if not requirement:
+                    lines.append("    (optional - no authentication required)")
+                    continue
+                key = next(iter(requirement))
                 lines.append(f"    {key}")
-                if value := security.get(key):
-                    value = ', '.join(value)
-                    lines.append(f"      - Required scopes: {value}")
+                if scopes := requirement.get(key):
+                    lines.append(f"      - Required scopes: {', '.join(scopes)}")
 
         return lines
 


### PR DESCRIPTION
## Summary

The `update-api-docs` workflow crashed because the OCS OpenAPI schema added `GET /api/v2/me/` with `security: [{}, ...]`. The empty requirement object (`{}`, meaning auth is optional) made `next(iter(requirement))` raise `StopIteration`.

Now empty requirements render as optional. Added a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)