### PR TITLE
Long Concept/Evaluations split out into new pages

### DIFF
--- a/docs/concepts/evaluations/dataset.md
+++ b/docs/concepts/evaluations/dataset.md
@@ -1,6 +1,6 @@
 # Evaluation Datasets
 
-**Datasets** are collections of messages that serve as the foundation for running evaluations.
+A **dataset** is the set of example conversations or messages you want to test your chatbot against — the input for an [evaluation](./index.md).
 
 ## Evaluation Levels
 
@@ -26,7 +26,7 @@ Each dataset row contains the following fields. Not all fields are populated for
 
 ## Managing Datasets
 
-Datasets can be created by cloning an existing session, manually created in the UI, uploaded with a CSV, or — for session-level datasets — auto-populated continuously from a source chatbot via [auto-population rules](#auto-population-rules).
+Datasets can be created by cloning an existing session, manually created in the UI, uploaded with a CSV, or — for session-level datasets — auto-populated continuously from a source chatbot via [auto-population rules](../../tech-hub/evaluations/auto_population.md).
 
 !!! note
     Manual creation and CSV upload are only available for **message-level** datasets. Session-level datasets must be populated by cloning sessions, by configuring an auto-population rule, or by importing sessions from an annotation queue.
@@ -48,7 +48,11 @@ When cloning a message-level session, dataset rows are created automatically fro
 | `trace.participant_data` | `participant_data` | Participant data captured at the time of the message |
 | `trace.session_state` | `session_state` | Session state captured at the time of the message |
 
-Selecting multiple sessions from the list will clone all the messages from those sessions. Selecting "filtered messages" will only clone the messages that match the filter parameters. Selecting "All messages" will clone every message in that session.
+When selecting messages to clone, you have three options:
+
+- **Multiple sessions** — clones all messages from each selected session(s).
+- **Filtered messages** — clones only the messages that match the active filter parameters.
+- **All messages** — clones every message in the session.
 
 Messages that are cloned from a session will be "connected" to their actual message in OCS, and you will be able to follow links back to their original conversation when viewing the output of an evaluator. However, modifying or updating a cloned message will break this link.
 
@@ -93,39 +97,6 @@ user: Please tell me the time.
 assistant: It is currently 12:05 PM in Ankara.
 ```
 
-## Auto-Population Rules
-
-Session-level datasets can be configured to **continuously ingest new sessions** from a source chatbot. Each dataset can have one or more **auto-population rules**, and each rule defines:
-
-- **Source chatbot**: The chatbot whose sessions should be considered for ingestion.
-- **Filter criteria**: Standard session filters (tags, participant, channel, date range, etc.) that determine which sessions match the rule.
-
-!!! note
-    Auto-population is available for **session-level** datasets only. Message-level datasets must be populated by cloning, manual entry, or CSV upload.
-
-### How ingestion works
-
-A background task polls each enabled rule every **5 minutes** and adds any new sessions that match its filters and are not already in the dataset. Ingestion is bounded:
-
-- Only sessions created **after the rule itself was created** are eligible — enabling a rule does not backfill historical sessions.
-- A configurable lookback window (default: 30 days) limits how far back the poller scans, based on session creation date. This means a rule will only ingest sessions created within the lookback window, even if they otherwise match the filter (e.g. a session tagged with a matching tag will only be picked up if it was created less than 30 days ago).
-
-If a rule fails repeatedly (e.g. due to a misconfigured filter or a transient database error), it is automatically **disabled after three consecutive failures** and a notification is raised so the rule can be reviewed.
-
-### Automatic delta evaluation runs
-
-Auto-population works together with the **auto-run** flag on evaluation configs. When new sessions are added to a dataset by an auto-population rule, any evaluation config that references that dataset *and* has the auto-run flag set will be triggered automatically against the newly added rows.
-
-Each automatic run scores only the rows added in that ingestion cycle, producing a **delta** result set rather than re-evaluating every row in the dataset. The evaluation run table lists both **full** runs (which score the entire dataset) and **delta** runs (which score only newly added rows), so you can track results from manual full runs and automatic delta runs side by side.
-
-Manual filter-import and CSV-import paths do not trigger automatic evaluation runs — only the auto-population path does.
-
-## Sharing Dataset Messages
-
-When viewing dataset messages in the table, each row includes a link button that allows you to share a direct link to that specific message. When someone follows this link, the page automatically scrolls to the message and highlights it for easy identification.
-
-This feature is useful for collaborating with team members, referencing specific test cases in discussions, or documenting particular dataset examples. Simply click the link icon next to any message, and the URL will be copied to your clipboard with the message ID parameter included.
-
 ### CSV Upload
 
 A CSV can also be uploaded to populate the dataset. There should be columns for human messages, ai responses, and any context data. You can also include `participant_data` and `session_state` fields.
@@ -156,3 +127,13 @@ You can also specify participant data and session state as raw JSON objects by u
 When uploading a CSV, you can populate the history automatically from previous messages, or add it as a separate column.
 
 Adding the history automatically assumes the CSV is the transcript of a single conversation, in chronological order.
+
+## Auto-Population
+
+Session-level datasets can be continuously and automatically populated with new sessions from a live chatbot, instead of being created manually or from a one-off import. See [Auto-Population Rules](../../tech-hub/evaluations/auto_population.md) for how to configure rules and how ingestion works.
+
+## Sharing Dataset Messages
+
+When viewing dataset messages in the table, each row includes a link button that allows you to share a direct link to that specific message. When someone follows this link, the page automatically scrolls to the message and highlights it for easy identification.
+
+This feature is useful for collaborating with team members, referencing specific test cases in discussions, or documenting particular dataset examples. Simply click the link icon next to any message, and the URL will be copied to your clipboard with the message ID parameter included.

--- a/docs/concepts/evaluations/dataset.md
+++ b/docs/concepts/evaluations/dataset.md
@@ -1,6 +1,10 @@
 # Evaluation Datasets
 
-A **dataset** is the set of example conversations or messages you want to test your chatbot against — the input for an [evaluation](./index.md).
+Every evaluation needs example conversations to test against — that's what a **dataset** provides. A dataset is the set of messages or sessions you want to score.
+
+Dataset quality matters more than dataset size: a small, well-chosen set of realistic examples tells you more about how your chatbot behaves than scoring everything that happens to exist.
+
+You can build a dataset from real conversations your chatbot has already had, or write your own test cases to check specific behaviors — including edge cases your chatbot hasn't encountered yet.
 
 ## Evaluation Levels
 

--- a/docs/concepts/evaluations/evaluators.md
+++ b/docs/concepts/evaluations/evaluators.md
@@ -1,8 +1,10 @@
 # Evaluators
 
-**Evaluators** define the logic for analyzing messages and generating evaluation metrics. Each evaluator takes individual messages from a dataset and optionally a generated response, then outputs structured results in a table.
+A dataset full of example conversations only becomes useful once it's been scored — that's the job of an **evaluator**. An evaluator looks at each message (and, optionally, your chatbot's generated response to it) and outputs a judgment: was it accurate, on-topic, polite, or whatever else matters for your use case.
 
-Each evaluator has an **evaluation mode** — either **message-level** or **session-level** — that must match the dataset it is used with. When configuring an evaluation run, evaluators whose mode is incompatible with the selected dataset are automatically disabled.
+You can run several evaluators over the same dataset at once, so a single evaluation run can check multiple things — accuracy, tone, safety — without re-running your chatbot for each one.
+
+Each evaluator works in one of two **evaluation modes** — **message-level** (judging a single response) or **session-level** (judging a whole conversation) — and must match the mode of the dataset it's used with. Evaluators using the wrong mode for a dataset are automatically disabled when configuring a run.
 
 ## Evaluator Types
 

--- a/docs/concepts/evaluations/evaluators.md
+++ b/docs/concepts/evaluations/evaluators.md
@@ -21,11 +21,11 @@ Generated answer: {generated_response}
 Consider the conversation context: {context.topic}
 ```
 
-**Template Variables:**
+### Template Variables
 
 The available variables depend on the evaluator's evaluation mode.
 
-##### Message-level variables
+**Message-level variables**
 
 | Variable | Description |
 |---|---|
@@ -35,7 +35,7 @@ The available variables depend on the evaluator's evaluation mode.
 | `{context.[parameter]}` | Any context variable, e.g. `{context.topic}` |
 | `{full_history}` | Complete conversation history as formatted text |
 
-##### Session-level variables
+**Session-level variables**
 
 In session-level mode, `{input.content}` and `{output.content}` are empty. Use the following variables instead:
 
@@ -49,7 +49,7 @@ In session-level mode, `{input.content}` and `{output.content}` are empty. Use t
 
 See [Evaluation Datasets](dataset.md) for how data is mapped into these fields.
 
-#### Output Schema
+### Output Schema
 
 The output schema defines the metrics that the LLM should attempt to output. Each item in the schema will become a column in the output table. You can specify the data type for each field to ensure structured, validated output.
 
@@ -71,63 +71,9 @@ The system automatically validates the LLM's output against the specified types 
 | user_sentiment | choices | The sentiment of the user message (options: positive, neutral, negative) |
 | confidence_score | float | Confidence in the evaluation, from 0.0 to 1.0 |
 
-#### Tag Rules
+See [Tag Rules](tag_rules.md) to automatically tag sessions or messages based on these output values.
 
-Tag Rules let you automatically apply tags to sessions or messages when an evaluator output field matches a condition. This makes it easy to surface and filter results — for example, flagging all sessions where the evaluator detected negative sentiment, or marking messages that scored below a threshold.
-
-Tag Rules are available only on LLM evaluators. They run automatically on every non-preview evaluation run. Preview runs do not trigger tag application.
-
-**How tags are applied**
-
-The target of the tag depends on the evaluator's mode:
-
-- **Message mode**: the tag is applied to the specific chat message being evaluated.
-- **Session mode**: the tag is applied to the session's chat.
-
-Each tag application is recorded in an audit log and displayed in the **Applied Tags** column on the run results page.
-
-**Tag reconciliation on rerun**
-
-The philosophy behind tag rules is simple: a message or session either meets the criteria for a tag, or it does not. To keep tag state consistent with the latest evaluation results, rerunning an evaluation reconciles the tags managed by its evaluators' tag rules:
-
-- For each message or session in the rerun's scope, any tag named by an evaluator's tag rules that was **not** applied by the latest run is removed from that message or session.
-- Reconciliation removes a tag regardless of who applied it. If a human had previously added a tag that is also managed by a tag rule, and the new evaluator output does not satisfy that rule, the human-applied tag is removed.
-- **FULL** reruns reconcile every row in the dataset. **DELTA** reruns only reconcile the rows in their scope.
-- **PREVIEW** runs neither apply nor remove tags.
-
-Tags whose names are not referenced by any tag rule on the run's evaluators are never touched by reconciliation.
-
-**Defining a rule**
-
-Each rule has three parts:
-
-| Field | Description |
-|-------|-------------|
-| Output field | The output schema field whose value is tested |
-| Tag name | The tag to apply when the condition is met |
-| Condition | The value or range that triggers the tag |
-
-The condition options vary by the type of the output field:
-
-| Output field type | Condition behaviour |
-|-------------------|---------------------|
-| choices (enum) | Apply the tag when the field equals one of the defined choice values (e.g. `sentiment == "negative"`) |
-| integer / float | Apply the tag when the field equals a specific value, or falls within a `min..max` range |
-| string | Apply the tag when the field equals a specific value |
-
-**Example Tag Rules**
-
-Given the output schema from the example above, you could define the following rules:
-
-| Output field | Tag name | Condition |
-|---|---|---|
-| user_sentiment | negative-sentiment | equals `negative` |
-| expected_helpfulness | low-helpfulness | range `1..2` |
-| confidence_score | low-confidence | range `0.0..0.4` |
-
-With these rules, any evaluation run will automatically tag messages or sessions that meet the conditions, without requiring manual review of every row.
-
-**Clearing run history**
+## Clearing Run History
 
 The evaluation runs page includes a **Clear all** button that deletes the entire run history for an evaluation config in a single action. This button is only shown to users who have delete permission for evaluation runs.
 
@@ -138,41 +84,8 @@ Clearing run history also removes the tags that those runs applied to their targ
 
 A confirmation prompt appears before the action runs.
 
-### Python Evaluator
+## Python Evaluator
 
-The Python Evaluator allows custom code execution against each message.
+Use the Python Evaluator when you need deterministic rules, custom string matching, or logic that an LLM prompt cannot reliably express. It runs custom code against each message instead of an LLM prompt.
 
-The code **must** define a `main` function which takes the `input`, `output`, `full_history`, and `generated_response`. It should return a `dict` whose keys will become columns in the output table.
-
-**Function Arguments:**
-
-| Argument | Type | Description | Example |
-|----------|------|-------------|---------|
-| `input` | dict | The human message data with `content` and `role` keys | `{'content': 'What is 2+2?', 'role': 'human'}` |
-| `output` | dict | The expected AI response with `content` and `role` keys | `{'content': '2+2 equals 4', 'role': 'ai'}` |
-| `context` | dict | Additional metadata and variables | `{'topic': 'math', 'difficulty': 'easy', 'user_id': '123'}` |
-| `full_history` | str | Complete conversation history | `"user: Hello\nassistant: Hi there!\nuser: What is 2+2?"` |
-| `generated_response` | str | AI-generated response being evaluated | `"The answer is 4. Is there anything else I can help with?"` |
-
-
-**Example:**
-
-```python
-def main(input: dict, output: dict, context: dict, full_history: str, generated_response: str, **kwargs) -> dict:
-    """Evaluates response quality based on accuracy, length, and politeness.
-    """
-
-    expected_answer = output['content'].lower()
-    actual_answer = generated_response.lower()
-    has_correct_answer = expected_answer in actual_answer
-
-    response_length = len(generated_response.split())
-    is_polite = any(word in actual_answer for word in ['please', 'thank', 'help', 'happy'])
-
-    return {
-        'correct_answer': has_correct_answer,
-        'response_length': response_length,
-        'politeness_score': 1.0 if is_polite else 0.0,
-        'topic': context.get('topic', 'unknown')
-    }
-```
+See [Python Evaluator](../../tech-hub/evaluations/python_evaluator.md) for the function signature, arguments, and a worked example.

--- a/docs/concepts/evaluations/evaluators.md
+++ b/docs/concepts/evaluations/evaluators.md
@@ -9,8 +9,9 @@ Each evaluator works in one of two **evaluation modes** — **message-level** (j
 ## Evaluator Types
 
 ### LLM Evaluator
-The LLM Evaluator uses language models to evaluate responses based on a custom prompt. This can be used as an LLM-as-judge to evaluate the performance of a chatbot, or to gain insight properties of both the user and assistant messages.
+The LLM Evaluator uses language models to evaluate responses based on a custom prompt. This can be used as an [LLM-as-judge](../../how-to/realtime_llm_judge.md) to evaluate the performance of a chatbot, or to gain insight properties of both the user and assistant messages.
 
+For the how to guide see [set up a real time LLM Judge](../../how-to/realtime_llm_judge.md).
 
 **Example prompt:**
 ```

--- a/docs/concepts/evaluations/evaluators.md
+++ b/docs/concepts/evaluations/evaluators.md
@@ -74,7 +74,13 @@ The system automatically validates the LLM's output against the specified types 
 | user_sentiment | choices | The sentiment of the user message (options: positive, neutral, negative) |
 | confidence_score | float | Confidence in the evaluation, from 0.0 to 1.0 |
 
-See [Tag Rules](tag_rules.md) to automatically tag sessions or messages based on these output values.
+See [Tag Rules](../evaluations/tag_rules.md) to automatically tag sessions or messages based on these output values.
+
+### Python Evaluator
+
+Use the Python Evaluator when you need deterministic rules, custom string matching, or logic that an LLM prompt cannot reliably express. It runs custom code against each message instead of an LLM prompt.
+
+See [Python Evaluator](../../tech-hub/evaluations/python_evaluator.md) for the function signature, arguments, and a worked example.
 
 ## Clearing Run History
 
@@ -86,9 +92,3 @@ Clearing run history also removes the tags that those runs applied to their targ
     Deleted runs and their results cannot be recovered. Export any results you need to keep before using **Clear all**.
 
 A confirmation prompt appears before the action runs.
-
-## Python Evaluator
-
-Use the Python Evaluator when you need deterministic rules, custom string matching, or logic that an LLM prompt cannot reliably express. It runs custom code against each message instead of an LLM prompt.
-
-See [Python Evaluator](../../tech-hub/evaluations/python_evaluator.md) for the function signature, arguments, and a worked example.

--- a/docs/concepts/evaluations/index.md
+++ b/docs/concepts/evaluations/index.md
@@ -1,22 +1,14 @@
 # Evaluations
 
-**Evaluations** is a testing system for measuring chatbot performance against different metrics.
+Evaluations let you check how well your chatbot is performing by running it against a set of sample conversations and automatically scoring the results — for example, checking whether responses were accurate, on-topic, or used the right tone.
 
-Evaluations can be run against existing conversation messages in the system or uploaded custom test datasets. Metrics can be defined either as python code, or output from an LLM.
+In Open Chat Studio, evaluations can be run against existing conversation messages in the system or uploaded custom test datasets. Metrics can be defined either as python code, or output from an LLM.
 
 ## Overview
 
-**Evaluations** are made up of a [dataset](./dataset.md) and one or more [evaluators](./evaluators.md).
-
-### Dataset
-
-**Datasets** are collections of messages that serve as the foundation for running evaluations.
-
-Datasets can either be created directly from existing [sessions](../sessions.md), manually created in the UI, or uploaded with a CSV.
-
-### Evaluator
-
-**Evaluators** define the logic for analyzing messages and generating evaluation metrics. Each evaluator takes individual messages from a dataset and optionally a generated response, then outputs structured results in a table. You can apply many evaluators to a dataset in parallel, and the outputs of each will be added as new columns to the table.
+- **Evaluations** are made up of a [dataset](./dataset.md) and one or more [evaluators](./evaluators.md).
+- **Datasets** are collections of messages that serve as the foundation for running evaluations. Datasets can either be created directly from existing [sessions](../sessions.md), manually created in the UI, or uploaded with a CSV.
+- **Evaluators** define the logic for analyzing messages and generating evaluation metrics. Each evaluator takes individual messages from a dataset and optionally a generated response, then outputs structured results in a table. You can apply many evaluators to a dataset in parallel, and the outputs of each will be added as new columns to the table.
 
 ### Chatbot Generation
 

--- a/docs/concepts/evaluations/index.md
+++ b/docs/concepts/evaluations/index.md
@@ -11,10 +11,11 @@ In Open Chat Studio, evaluations can be run against existing conversation messag
 - **Evaluations** are made up of a [dataset](./dataset.md) and one or more [evaluators](./evaluators.md).
 - **Datasets** are collections of test case messages that serve as the foundation for running evaluations. Datasets can either be created directly from existing [sessions](../sessions.md), manually created in the UI, or uploaded with a CSV. They are inputs for an evaluation.
 - **Evaluators** define the logic for analyzing messages and generating evaluation metrics, either as an [LLM-as-judge prompt](./evaluators.md#llm-evaluator) or [custom python code](./evaluators.md#python-evaluator). Each evaluator takes individual messages from a dataset and optionally a generated response, then outputs structured results in a table. You can apply many evaluators to a dataset in parallel, and the outputs of each will be added as new columns to the table.
+- **[Tag Rules](./tag_rules.md)** automatically tag sessions or messages whose evaluator output meets a condition you define, such as a low confidence score or negative sentiment, so you can jump straight to the conversations that need attention.
 
 ## Evaluation Execution
 
-When an evaluation is run, each message from the dataset is first passed in to the defined chatbot (if applicaple). The result, with the added generation output is then passed in to each evaluator in parallel. The evaluators output structured data. This data is compiled into a table, whose rows are each message and the columns are the evaluator output.
+When an evaluation is run, each message from the dataset is first passed in to the defined chatbot (if applicable). The result, with the added generation output is then passed in to each evaluator in parallel. The evaluators output structured data. This data is compiled into a table, whose rows are each message and the columns are the evaluator output.
 
 ```mermaid
 flowchart LR
@@ -38,4 +39,3 @@ When evaluations are run with chatbot generation enabled, temporary sessions are
 
 !!! note "Source Sessions Unaffected"
     This automatic deletion only affects sessions created during evaluation runs. Source sessions (the original sessions that datasets may be cloned from) are not affected by this retention policy and remain in the system according to their own lifecycle.
-

--- a/docs/concepts/evaluations/index.md
+++ b/docs/concepts/evaluations/index.md
@@ -1,13 +1,15 @@
 # Evaluations
 
-Evaluations let you check how well your chatbot is performing by running it against a set of sample conversations and automatically scoring the results — for example, checking whether responses were accurate, on-topic, or used the right tone.
+Building a chatbot is the easy part. Knowing if it's actually working well — especially as you tweak prompts, swap models, or add new features — is harder. **Evaluations** let you check this systematically: run your chatbot against a set of sample conversations, and automatically score the results against criteria you define, such as accuracy, tone, or whether it stayed on topic.
 
-In Open Chat Studio, evaluations can be run against existing conversation messages in the system or uploaded custom test datasets.
+Running evaluations regularly gives you an early warning when a change makes responses worse, and proof when a change makes them better — instead of relying on spot-checking conversations by hand.
+
+In Open Chat Studio, evaluations can be run against existing conversation messages already in the system, or against a custom set of test cases you upload.
 
 ## Overview
 
 - **Evaluations** are made up of a [dataset](./dataset.md) and one or more [evaluators](./evaluators.md).
-- **Datasets** are collections of messages that serve as the foundation for running evaluations. Datasets can either be created directly from existing [sessions](../sessions.md), manually created in the UI, or uploaded with a CSV.
+- **Datasets** are collections of test case messages that serve as the foundation for running evaluations. Datasets can either be created directly from existing [sessions](../sessions.md), manually created in the UI, or uploaded with a CSV. They are inputs for an evaluation.
 - **Evaluators** define the logic for analyzing messages and generating evaluation metrics, either as an [LLM-as-judge prompt](./evaluators.md#llm-evaluator) or [custom python code](./evaluators.md#python-evaluator). Each evaluator takes individual messages from a dataset and optionally a generated response, then outputs structured results in a table. You can apply many evaluators to a dataset in parallel, and the outputs of each will be added as new columns to the table.
 
 ## Evaluation Execution

--- a/docs/concepts/evaluations/index.md
+++ b/docs/concepts/evaluations/index.md
@@ -2,17 +2,13 @@
 
 Evaluations let you check how well your chatbot is performing by running it against a set of sample conversations and automatically scoring the results — for example, checking whether responses were accurate, on-topic, or used the right tone.
 
-In Open Chat Studio, evaluations can be run against existing conversation messages in the system or uploaded custom test datasets. Metrics can be defined either as python code, or output from an LLM.
+In Open Chat Studio, evaluations can be run against existing conversation messages in the system or uploaded custom test datasets.
 
 ## Overview
 
 - **Evaluations** are made up of a [dataset](./dataset.md) and one or more [evaluators](./evaluators.md).
 - **Datasets** are collections of messages that serve as the foundation for running evaluations. Datasets can either be created directly from existing [sessions](../sessions.md), manually created in the UI, or uploaded with a CSV.
-- **Evaluators** define the logic for analyzing messages and generating evaluation metrics. Each evaluator takes individual messages from a dataset and optionally a generated response, then outputs structured results in a table. You can apply many evaluators to a dataset in parallel, and the outputs of each will be added as new columns to the table.
-
-### Chatbot Generation
-
-Messages can also optionally be passed in to a [chatbot](../chatbots/index.md), whose generation output will be available to the evaluators.
+- **Evaluators** define the logic for analyzing messages and generating evaluation metrics, either as an [LLM-as-judge prompt](./evaluators.md#llm-evaluator) or [custom python code](./evaluators.md#python-evaluator). Each evaluator takes individual messages from a dataset and optionally a generated response, then outputs structured results in a table. You can apply many evaluators to a dataset in parallel, and the outputs of each will be added as new columns to the table.
 
 ## Evaluation Execution
 
@@ -27,7 +23,11 @@ flowchart LR
     evaluator2 --> structured_output
 ```
 
-## Session Retention
+### Chatbot Generation
+
+Messages can also optionally be passed in to a [chatbot](../chatbots/index.md), whose generation output will be available to the evaluators.
+
+### Session Retention
 
 When evaluations are run with chatbot generation enabled, temporary sessions are created to store the generated responses and conversation context. These evaluation sessions are automatically deleted after **30 days**.
 
@@ -36,3 +36,4 @@ When evaluations are run with chatbot generation enabled, temporary sessions are
 
 !!! note "Source Sessions Unaffected"
     This automatic deletion only affects sessions created during evaluation runs. Source sessions (the original sessions that datasets may be cloned from) are not affected by this retention policy and remain in the system according to their own lifecycle.
+

--- a/docs/concepts/evaluations/tag_rules.md
+++ b/docs/concepts/evaluations/tag_rules.md
@@ -38,7 +38,7 @@ Each rule has three parts:
 
 The condition options vary by the type of the output field:
 
-| Output field type | Condition behaviour |
+| Output field type | Condition behavior
 |-------------------|---------------------|
 | choices (enum) | Apply the tag when the field equals one of the defined choice values (e.g. `sentiment == "negative"`) |
 | integer / float | Apply the tag when the field equals a specific value, or falls within a `min..max` range |

--- a/docs/concepts/evaluations/tag_rules.md
+++ b/docs/concepts/evaluations/tag_rules.md
@@ -1,0 +1,55 @@
+# Tag Rules
+
+Tag Rules let you automatically apply tags to sessions or messages when an evaluator output field matches a condition. This makes it easy to surface and filter results — for example, flagging all sessions where the evaluator detected negative sentiment, or marking messages that scored below a threshold.
+
+Tag Rules are available only on [LLM evaluators](evaluators.md#llm-evaluator). They run automatically on every non-preview evaluation run. Preview runs do not trigger tag application.
+
+## How tags are applied
+
+The target of the tag depends on the evaluator's mode:
+
+- **Message mode**: the tag is applied to the specific chat message being evaluated.
+- **Session mode**: the tag is applied to the session's chat.
+
+Each tag application is recorded in an audit log and displayed in the **Applied Tags** column on the run results page.
+
+## Tag reconciliation on rerun
+
+The philosophy behind tag rules is simple: a message or session either meets the criteria for a tag, or it does not. To keep tag state consistent with the latest evaluation results, rerunning an evaluation reconciles the tags managed by its evaluators' tag rules:
+
+- For each message or session in the rerun's scope, any tag named by an evaluator's tag rules that was **not** applied by the latest run is removed from that message or session.
+- Reconciliation removes a tag regardless of who applied it. If a human had previously added a tag that is also managed by a tag rule, and the new evaluator output does not satisfy that rule, the human-applied tag is removed.
+- **FULL** runs (which score the entire dataset) reconcile every row. **DELTA** runs (which score only newly added rows, triggered automatically by [auto-population](../../tech-hub/evaluations/auto_population.md)) reconcile only the rows in their scope.
+- **PREVIEW** runs neither apply nor remove tags.
+
+Tags whose names are not referenced by any tag rule on the run's evaluators are never touched by reconciliation.
+
+## Defining a rule
+
+Each rule has three parts:
+
+| Field | Description |
+|-------|-------------|
+| Output field | The output schema field whose value is tested |
+| Tag name | The tag to apply when the condition is met |
+| Condition | The value or range that triggers the tag |
+
+The condition options vary by the type of the output field:
+
+| Output field type | Condition behaviour |
+|-------------------|---------------------|
+| choices (enum) | Apply the tag when the field equals one of the defined choice values (e.g. `sentiment == "negative"`) |
+| integer / float | Apply the tag when the field equals a specific value, or falls within a `min..max` range |
+| string | Apply the tag when the field equals a specific value |
+
+## Example
+
+Using the [example output schema](evaluators.md#output-schema) from the Evaluators page, you could define the following rules:
+
+| Output field | Tag name | Condition |
+|---|---|---|
+| user_sentiment | negative-sentiment | equals `negative` |
+| expected_helpfulness | low-helpfulness | range `1..2` |
+| confidence_score | low-confidence | range `0.0..0.4` |
+
+With these rules, any evaluation run will automatically tag messages or sessions that meet the conditions, without requiring manual review of every row.

--- a/docs/concepts/evaluations/tag_rules.md
+++ b/docs/concepts/evaluations/tag_rules.md
@@ -1,8 +1,10 @@
 # Tag Rules
 
-Tag Rules let you automatically apply tags to sessions or messages when an evaluator output field matches a condition. This makes it easy to surface and filter results — for example, flagging all sessions where the evaluator detected negative sentiment, or marking messages that scored below a threshold.
+Running an evaluation against hundreds of messages produces a results table too large to read row by row. **Tag Rules** solve this by automatically tagging the sessions or messages that meet a condition you define.
 
-Tag Rules are available only on [LLM evaluators](evaluators.md#llm-evaluator). They run automatically on every non-preview evaluation run. Preview runs do not trigger tag application.
+For example, you could flag every session with negative sentiment, or every response that scored below a threshold — so your team can jump straight to the conversations that need attention instead of reviewing everything.
+
+Tag Rules are available only on [LLM evaluators](evaluators.md#llm-evaluator). They run automatically on every non-preview evaluation run; preview runs do not trigger tag application.
 
 ## How tags are applied
 

--- a/docs/how-to/realtime_llm_judge.md
+++ b/docs/how-to/realtime_llm_judge.md
@@ -1,6 +1,6 @@
 # Set Up a Real-Time LLM Judge
 
-This guide shows you how to configure an LLM-as-a-judge that scores new chatbot sessions automatically as they arrive, with no manual intervention required. The pattern combines a session-level dataset that continuously ingests new sessions from a chatbot with an LLM evaluator set to run automatically on each new batch.
+This guide shows you how to configure an LLM-as-a-judge that scores new chatbot sessions automatically as they arrive, with no manual intervention required. The pattern combines a [session-level dataset](../concepts/evaluations/dataset.md#session-level-datasets) that continuously ingests new sessions from a chatbot with an [LLM evaluator](../concepts/evaluations/evaluators.md#llm-evaluator) set to run automatically on each new batch.
 
 For background on evaluations, datasets, and evaluators, see [Evaluations](../concepts/evaluations/index.md).
 
@@ -17,7 +17,7 @@ See [Evaluation Datasets](../concepts/evaluations/dataset.md) for an overview of
 
 ## Step 2: Add an auto-population rule
 
-Once the dataset exists, add an auto-population rule to tell OCS which chatbot sessions should flow into it.
+Once the dataset exists, add an auto-population rule to tell OCS which chatbot sessions should flow into it. For full details, see [Auto-Population Rules](../tech-hub/evaluations/auto_population.md).
 
 Each rule requires:
 
@@ -29,13 +29,7 @@ A dataset can have more than one rule — useful if you want to combine sessions
 !!! note
     A rule only ingests sessions created **after the rule itself was created**. Enabling a rule does not backfill historical sessions.
 
-**How ingestion works once the rule is active:**
-
-- A background task polls each enabled rule every **5 minutes** and adds any new matching sessions not already in the dataset.
-- A configurable lookback window (default: 30 days) limits how far back the poller scans, based on session creation date.
-- If a rule fails three consecutive times, it is **automatically disabled** and a notification is raised. If ingestion appears to have stopped, check whether the rule is still enabled.
-
-For full details, see [Auto-Population Rules](../tech-hub/evaluations/auto_population.md).
+For full details of **how ingestion works once the rule is active**, see [Auto-Population Rules on Tech Hub](../tech-hub/evaluations/auto_population.md#how-ingestion-works).
 
 ## Step 3: Create a session-level LLM evaluator
 
@@ -77,7 +71,7 @@ See [Evaluators](../concepts/evaluations/evaluators.md) for full details on outp
 
 ## Step 4 (optional): Add tag rules to flag results automatically
 
-Tag rules apply a tag to a session automatically when an evaluator output field meets a condition. They run on every non-preview evaluation run and make it easy to surface sessions of interest without reviewing every row.
+[Tag rules](../concepts/evaluations/tag_rules.md) apply a tag to a session automatically when an evaluator output field meets a condition. They run on every non-preview evaluation run and make it easy to surface sessions of interest without reviewing every row.
 
 In session mode, the tag is applied to the session's chat. Each application is recorded in the **Applied Tags** column on the run results page.
 

--- a/docs/how-to/realtime_llm_judge.md
+++ b/docs/how-to/realtime_llm_judge.md
@@ -121,4 +121,4 @@ After setup, confirm the pipeline is running end to end:
 2. **Delta runs appear in the run table** — each ingestion cycle that adds new sessions should produce a corresponding delta run entry.
 3. **Tags appear on matching sessions** — if you configured tag rules, check the Applied Tags column on the run results page and verify that sessions meeting the conditions are tagged.
 
-If sessions are not appearing, verify that the auto-population rule is still enabled (see Step 2 for the three-failure auto-disable behaviour).
+If sessions are not appearing, verify that the auto-population rule is still enabled (see Step 2 for the three-failure auto-disable behavior).

--- a/docs/how-to/realtime_llm_judge.md
+++ b/docs/how-to/realtime_llm_judge.md
@@ -35,7 +35,7 @@ A dataset can have more than one rule — useful if you want to combine sessions
 - A configurable lookback window (default: 30 days) limits how far back the poller scans, based on session creation date.
 - If a rule fails three consecutive times, it is **automatically disabled** and a notification is raised. If ingestion appears to have stopped, check whether the rule is still enabled.
 
-For full details, see [Auto-Population Rules](../concepts/evaluations/dataset.md#auto-population-rules).
+For full details, see [Auto-Population Rules](../tech-hub/evaluations/auto_population.md).
 
 ## Step 3: Create a session-level LLM evaluator
 
@@ -93,7 +93,7 @@ With these rules in place, sessions where the goal was not met or where quality 
 !!! tip
     Tagged sessions can be filtered in the session list, so your team can prioritise follow-up without wading through all results.
 
-See [Tag Rules](../concepts/evaluations/evaluators.md#tag-rules) for the full set of condition types.
+See [Tag Rules](../concepts/evaluations/tag_rules.md) for the full set of condition types.
 
 ## Step 5: Create an evaluation config with auto-run enabled
 

--- a/docs/tech-hub/evaluations/auto_population.md
+++ b/docs/tech-hub/evaluations/auto_population.md
@@ -15,7 +15,7 @@ Session-level datasets can be configured to **continuously ingest new sessions**
 A background task polls each enabled rule every **5 minutes** and adds any new sessions that match its filters and are not already in the dataset. Ingestion is bounded:
 
 - Only sessions created **after the rule itself was created** are eligible — enabling a rule does not backfill historical sessions.
-- A configurable lookback window (default: 30 days) limits how far back the poller scans, based on session creation date. This means a rule will only ingest sessions created within the lookback window, even if they otherwise match the filter (e.g. a session tagged with a matching tag will only be picked up if it was created less than 30 days ago).
+- A configurable lookback window (default: 30 days) limits how far back the poller scans, based on session creation date. This means a rule will only ingest sessions created within the lookback window, even if they otherwise match the filter (e.g. a session matching a tag filter will only be picked up if it was created less than 30 days ago).
 
 If a rule fails repeatedly (e.g. due to a misconfigured filter or a transient database error), it is automatically **disabled after three consecutive failures** and a notification is raised so the rule can be reviewed.
 

--- a/docs/tech-hub/evaluations/auto_population.md
+++ b/docs/tech-hub/evaluations/auto_population.md
@@ -1,6 +1,4 @@
-# Auto-Population Rules
-
-See [Evaluation Datasets](../../concepts/evaluations/dataset.md#evaluation-levels) for an overview of session-level vs. message-level datasets.
+# Auto-Population Rules for datasets
 
 Session-level datasets can be configured to **continuously ingest new sessions** from a source chatbot. Each dataset can have one or more **auto-population rules**, and each rule defines:
 
@@ -9,6 +7,8 @@ Session-level datasets can be configured to **continuously ingest new sessions**
 
 !!! note
     Auto-population is available for **session-level** datasets only. Message-level datasets must be populated by cloning, manual entry, or CSV upload.
+
+    See [Evaluation Datasets](../../concepts/evaluations/dataset.md#evaluation-levels) for an overview of session-level vs. message-level datasets.
 
 ## How ingestion works
 

--- a/docs/tech-hub/evaluations/auto_population.md
+++ b/docs/tech-hub/evaluations/auto_population.md
@@ -1,0 +1,28 @@
+# Auto-Population Rules
+
+See [Evaluation Datasets](../../concepts/evaluations/dataset.md#evaluation-levels) for an overview of session-level vs. message-level datasets.
+
+Session-level datasets can be configured to **continuously ingest new sessions** from a source chatbot. Each dataset can have one or more **auto-population rules**, and each rule defines:
+
+- **Source chatbot**: The chatbot whose sessions should be considered for ingestion.
+- **Filter criteria**: Standard session filters (tags, participant, channel, date range, etc.) that determine which sessions match the rule.
+
+!!! note
+    Auto-population is available for **session-level** datasets only. Message-level datasets must be populated by cloning, manual entry, or CSV upload.
+
+## How ingestion works
+
+A background task polls each enabled rule every **5 minutes** and adds any new sessions that match its filters and are not already in the dataset. Ingestion is bounded:
+
+- Only sessions created **after the rule itself was created** are eligible — enabling a rule does not backfill historical sessions.
+- A configurable lookback window (default: 30 days) limits how far back the poller scans, based on session creation date. This means a rule will only ingest sessions created within the lookback window, even if they otherwise match the filter (e.g. a session tagged with a matching tag will only be picked up if it was created less than 30 days ago).
+
+If a rule fails repeatedly (e.g. due to a misconfigured filter or a transient database error), it is automatically **disabled after three consecutive failures** and a notification is raised so the rule can be reviewed.
+
+## Automatic delta evaluation runs
+
+Auto-population works together with the **auto-run** flag on evaluation configs. When new sessions are added to a dataset by an auto-population rule, any evaluation config that references that dataset *and* has the auto-run flag set will be triggered automatically against the newly added rows.
+
+Each automatic run scores only the rows added in that ingestion cycle, producing a **delta** result set rather than re-evaluating every row in the dataset. The evaluation run table lists both **full** runs (which score the entire dataset) and **delta** runs (which score only newly added rows), so you can track results from manual full runs and automatic delta runs side by side.
+
+Manual filter-import and CSV-import paths do not trigger automatic evaluation runs — only the auto-population path does.

--- a/docs/tech-hub/evaluations/index.md
+++ b/docs/tech-hub/evaluations/index.md
@@ -1,6 +1,6 @@
 # Evaluations
 
-This section covers the advanced features for Open Chat Studio's evaluation features: writing custom Python evaluators and configuring continuous dataset ingestion.
+This section covers Open Chat Studio's advanced evaluation features: writing custom Python evaluators and configuring continuous dataset ingestion.
 
 For a non-technical overview of datasets, evaluators, and how evaluation runs work, see [Evaluations](../../concepts/evaluations/index.md).
 

--- a/docs/tech-hub/evaluations/index.md
+++ b/docs/tech-hub/evaluations/index.md
@@ -1,0 +1,10 @@
+# Evaluations
+
+This section covers the advanced features for Open Chat Studio's evaluation features: writing custom Python evaluators and configuring continuous dataset ingestion.
+
+For a non-technical overview of datasets, evaluators, and how evaluation runs work, see [Evaluations](../../concepts/evaluations/index.md).
+
+## Pages in this section
+
+- **[Python Evaluator](./python_evaluator.md)** — write custom Python code to score messages, for deterministic rules or logic an LLM prompt can't reliably express. See [Evaluators](../../concepts/evaluations/evaluators.md#python-evaluator) for when to choose it over the LLM Evaluator.
+- **[Auto-Population Rules](./auto_population.md)** — continuously ingest new sessions into a session-level dataset from a live chatbot, and trigger automatic delta evaluation runs against the new rows.

--- a/docs/tech-hub/evaluations/python_evaluator.md
+++ b/docs/tech-hub/evaluations/python_evaluator.md
@@ -2,7 +2,7 @@
 
 The Python Evaluator runs custom code against each message — useful for deterministic rules, custom string matching, or logic an LLM prompt can't reliably express. See [Evaluators](../../concepts/evaluations/evaluators.md#python-evaluator) for when to choose it over the [LLM Evaluator](../../concepts/evaluations/evaluators.md#llm-evaluator).
 
-The code **must** define a `main` function which takes the `input`, `output`, `full_history`, and `generated_response`. It should return a `dict` whose keys will become columns in the output table.
+The code **must** define a `main` function which takes the `input`, `output`, `full_history`, and `generated_response` as arguments. It should return a `dict` whose keys will become columns in the output table.
 
 ## Function Arguments
 

--- a/docs/tech-hub/evaluations/python_evaluator.md
+++ b/docs/tech-hub/evaluations/python_evaluator.md
@@ -1,0 +1,37 @@
+# Python Evaluator
+
+The Python Evaluator runs custom code against each message — useful for deterministic rules, custom string matching, or logic an LLM prompt can't reliably express. See [Evaluators](../../concepts/evaluations/evaluators.md#python-evaluator) for when to choose it over the [LLM Evaluator](../../concepts/evaluations/evaluators.md#llm-evaluator).
+
+The code **must** define a `main` function which takes the `input`, `output`, `full_history`, and `generated_response`. It should return a `dict` whose keys will become columns in the output table.
+
+## Function Arguments
+
+| Argument | Type | Description | Example |
+|----------|------|-------------|---------|
+| `input` | dict | The human message data with `content` and `role` keys | `{'content': 'What is 2+2?', 'role': 'human'}` |
+| `output` | dict | The expected AI response with `content` and `role` keys | `{'content': '2+2 equals 4', 'role': 'ai'}` |
+| `context` | dict | Additional metadata and variables | `{'topic': 'math', 'difficulty': 'easy', 'user_id': '123'}` |
+| `full_history` | str | Complete conversation history | `"user: Hello\nassistant: Hi there!\nuser: What is 2+2?"` |
+| `generated_response` | str | AI-generated response being evaluated | `"The answer is 4. Is there anything else I can help with?"` |
+
+## Example
+
+```python
+def main(input: dict, output: dict, context: dict, full_history: str, generated_response: str, **kwargs) -> dict:
+    """Evaluates response quality based on accuracy, length, and politeness.
+    """
+
+    expected_answer = output['content'].lower()
+    actual_answer = generated_response.lower()
+    has_correct_answer = expected_answer in actual_answer
+
+    response_length = len(generated_response.split())
+    is_polite = any(word in actual_answer for word in ['please', 'thank', 'help', 'happy'])
+
+    return {
+        'correct_answer': has_correct_answer,
+        'response_length': response_length,
+        'politeness_score': 1.0 if is_polite else 0.0,
+        'topic': context.get('topic', 'unknown')
+    }
+```

--- a/docs/tech-hub/evaluations/python_evaluator.md
+++ b/docs/tech-hub/evaluations/python_evaluator.md
@@ -2,7 +2,7 @@
 
 The Python Evaluator runs custom code against each message — useful for deterministic rules, custom string matching, or logic an LLM prompt can't reliably express. See [Evaluators](../../concepts/evaluations/evaluators.md#python-evaluator) for when to choose it over the [LLM Evaluator](../../concepts/evaluations/evaluators.md#llm-evaluator).
 
-The code **must** define a `main` function which takes the `input`, `output`, `context`, full_history`, and `generated_response` as arguments. It should return a `dict` whose keys will become columns in the output table.
+The code **must** define a `main` function which takes the `input`, `output`, `context`, `full_history`, and `generated_response` as arguments. It should return a `dict` whose keys will become columns in the output table.
 
 ## Function Arguments
 

--- a/docs/tech-hub/evaluations/python_evaluator.md
+++ b/docs/tech-hub/evaluations/python_evaluator.md
@@ -2,7 +2,7 @@
 
 The Python Evaluator runs custom code against each message — useful for deterministic rules, custom string matching, or logic an LLM prompt can't reliably express. See [Evaluators](../../concepts/evaluations/evaluators.md#python-evaluator) for when to choose it over the [LLM Evaluator](../../concepts/evaluations/evaluators.md#llm-evaluator).
 
-The code **must** define a `main` function which takes the `input`, `output`, `full_history`, and `generated_response` as arguments. It should return a `dict` whose keys will become columns in the output table.
+The code **must** define a `main` function which takes the `input`, `output`, `context`, full_history`, and `generated_response` as arguments. It should return a `dict` whose keys will become columns in the output table.
 
 ## Function Arguments
 

--- a/docs/tech-hub/index.md
+++ b/docs/tech-hub/index.md
@@ -18,5 +18,5 @@ These topics contain technical facts and code examples.
 - **[Python Node](python_node.md)** — Write custom Python code inside a Pipeline to perform logic, process data, manage session state, and make HTTP requests to external services.
 - **[Render a Template and Send an Email Nodes](template_and_email_nodes.md)** — Full Jinja2 variable reference, recipient field syntax, and examples for the Render a Template and Send an Email pipeline nodes.
 - **[Tools Reference](tools.md)** — Full argument reference for all built-in tools and the LLM provider tools supported. For a conceptual overview, see [Tools Concepts](../concepts/tools/index.md).
-- **[Evaluations](evaluations.md/index)** — Reference for advanced features of Evaluations — a testing system for measuring chatbot performance against different metrics.
+- **[Evaluations](evaluations/index.md)** — Reference for advanced features of Evaluations — a testing system for measuring chatbot performance against different metrics.
 - **[OCS API Access](api_access.md)** — Interact with OCS chatbots programmatically using the REST API. Useful for third-party integrations and automated evaluation.

--- a/docs/tech-hub/index.md
+++ b/docs/tech-hub/index.md
@@ -18,5 +18,5 @@ These topics contain technical facts and code examples.
 - **[Python Node](python_node.md)** — Write custom Python code inside a Pipeline to perform logic, process data, manage session state, and make HTTP requests to external services.
 - **[Render a Template and Send an Email Nodes](template_and_email_nodes.md)** — Full Jinja2 variable reference, recipient field syntax, and examples for the Render a Template and Send an Email pipeline nodes.
 - **[Tools Reference](tools.md)** — Full argument reference for all built-in tools and the LLM provider tools supported. For a conceptual overview, see [Tools Concepts](../concepts/tools/index.md).
-- **[Render a Template and Send an Email Nodes](template_and_email_nodes.md)** — Full Jinja2 variable reference, recipient field syntax, and examples for the Render a Template and Send an Email pipeline nodes.
+- **[Evaluations](evaluations.md/index)** — Reference for advanced features of Evaluations — a testing system for measuring chatbot performance against different metrics.
 - **[OCS API Access](api_access.md)** — Interact with OCS chatbots programmatically using the REST API. Useful for third-party integrations and automated evaluation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
         - Custom Action Health: tech-hub/custom_action/health_custom_action.md
         - Custom Action Testing: tech-hub/custom_action/test_custom_action.md
     - Evaluations:
+        - tech-hub/evaluations/index.md
         - Python Evaluator: tech-hub/evaluations/python_evaluator.md
         - Auto-Population Rules: tech-hub/evaluations/auto_population.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,7 @@ nav:
         - concepts/evaluations/index.md
         - concepts/evaluations/dataset.md
         - concepts/evaluations/evaluators.md
+        - Tag Rules: concepts/evaluations/tag_rules.md
       - Annotations:
         - concepts/annotations/index.md
         - concepts/annotations/queues.md
@@ -181,6 +182,9 @@ nav:
         - tech-hub/custom_action/index.md
         - Custom Action Health: tech-hub/custom_action/health_custom_action.md
         - Custom Action Testing: tech-hub/custom_action/test_custom_action.md
+    - Evaluations:
+        - Python Evaluator: tech-hub/evaluations/python_evaluator.md
+        - Auto-Population Rules: tech-hub/evaluations/auto_population.md
 
     - OCS API:
         - api/index.md


### PR DESCRIPTION
### Overview of Approach

**Targeted extraction (minimal disruption)**

Leave the three existing CONCEPT pages and their nav position alone, but carve the three largest, most self-contained blocks out into their own pages — these are the sections currently making dataset.md and evaluators.md long and mixed-audience:

### Changes made

1. 3 new pages
2. Concept pages intros include why, how and benefit for new readers


**New pages:**

- concepts/evaluations/tag_rules.md — Tag Rules, extracted from evaluators.md
- tech-hub/evaluations/python_evaluator.md — Python Evaluator code/reference, extracted from evaluators.md
- tech-hub/evaluations/auto_population.md— Auto-population mechanics, extracted from dataset.md