### PR TITLE
Enable more markdown lint checking rules for pre-commit

### DIFF
--- a/.github/templates/changelog-instructions.md
+++ b/.github/templates/changelog-instructions.md
@@ -11,7 +11,7 @@ You need to update the changelog and documentation in this repository based on a
 
 ## PR Description
 
-```
+```text
 ${PR_BODY}
 ```
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -49,16 +49,12 @@ MD030: false
 MD032: false
 MD034: false
 MD036: false
-
 MD041: false
 
 # TODO: enable this for alt text on images for accessibility, but disable for now because we have some images without alt text
 MD045: false
 MD046: false
 MD050: false
-
-# TODO: enable this for valid link fragments, but disable for now because we have some invalid links in the docs
-#MD051: false
 MD053: false
 MD054: false
 MD058: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -58,7 +58,7 @@ MD046: false
 MD050: false
 
 # TODO: enable this for valid link fragments, but disable for now because we have some invalid links in the docs
-MD051: false
+#MD051: false
 MD053: false
 MD054: false
 MD058: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -50,8 +50,6 @@ MD032: false
 MD034: false
 MD036: false
 
-# TODO: enable this for code fence langague tags, but disable for now because we have some code fences without language tags
-MD040: false
 MD041: false
 
 # TODO: enable this for alt text on images for accessibility, but disable for now because we have some images without alt text

--- a/docs/api/getting_started_with_oauth.md
+++ b/docs/api/getting_started_with_oauth.md
@@ -80,7 +80,7 @@ https://www.openchatstudio.com/o/authorize/?response_type=code&client_id=${CLIEN
 
 After the user grants permission, OpenChatStudio redirects them to your `redirect_uri` with the authorization code in the query string:
 
-```
+```text
 https://your-server/callback/?code=auth_code_here&state=random_state_string
 ```
 
@@ -94,7 +94,7 @@ https://your-server/callback/?code=auth_code_here&state=random_state_string
 
 If an error occurs, the redirect will include error parameters:
 
-```
+```text
 https://your-server/callback/?error=access_denied&error_description=The+user+denied+the+request&state=random_state_string
 ```
 

--- a/docs/api/getting_started_with_oauth.md
+++ b/docs/api/getting_started_with_oauth.md
@@ -80,7 +80,7 @@ https://www.openchatstudio.com/o/authorize/?response_type=code&client_id=${CLIEN
 
 After the user grants permission, OpenChatStudio redirects them to your `redirect_uri` with the authorization code in the query string:
 
-```text
+```uri
 https://your-server/callback/?code=auth_code_here&state=random_state_string
 ```
 
@@ -94,7 +94,7 @@ https://your-server/callback/?code=auth_code_here&state=random_state_string
 
 If an error occurs, the redirect will include error parameters:
 
-```text
+```uri
 https://your-server/callback/?error=access_denied&error_description=The+user+denied+the+request&state=random_state_string
 ```
 

--- a/docs/api/v1/channels.txt
+++ b/docs/api/v1/channels.txt
@@ -16,13 +16,13 @@ Provide either ``prompt_text`` (routes through the LLM/bot pipeline) or ``messag
     Content: application/json
     Schema: TriggerBotMessageRequest
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: TriggerBotMessageResponse
-    400: 
+    400:
       Content: application/json
       Schema: Unknown
-    404: 
+    404:
       Content: application/json
       Schema: Unknown
   Security:
@@ -39,7 +39,7 @@ POST /channels/api/{experiment_id}/incoming_message
     Content: application/json
     Schema: ApiMessage
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ApiResponseMessage
   Security:
@@ -58,7 +58,7 @@ POST /channels/api/{experiment_id}/v{version}/incoming_message
     Content: application/json
     Schema: ApiMessage
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ApiResponseMessage
   Security:

--- a/docs/api/v1/chat.txt
+++ b/docs/api/v1/chat.txt
@@ -2,9 +2,9 @@ API: Open Chat Studio v1
 Description: Build, deploy and monitor chatbots.
 
 TAG: Chat
-Description: 
+Description:
                 The Chat API is designed to be used for integrating chatbots into external systems.
-            
+
 
 ENDPOINTS:
 
@@ -14,16 +14,16 @@ GET /api/chat/{session_id}/{task_id}/poll/
     - session_id (path, string (required)): Session ID
     - task_id (path, string (required)): Check on the status of a specific task
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ChatTaskPoll
-    400: 
+    400:
       Content: application/json
       Schema: ChatTaskPollUserError
-    404: 
+    404:
       Content: application/json
       Schema: ChatTaskPollNotFound
-    500: 
+    500:
       Content: application/json
       Schema: ChatTaskPollError
   Security:
@@ -38,7 +38,7 @@ POST /api/chat/{session_id}/message/
     Content: application/json
     Schema: ChatSendMessageRequestWithAttachments
   Responses:
-    202: 
+    202:
       Content: application/json
       Schema: ChatSendMessageResponse
   Security:
@@ -53,7 +53,7 @@ GET /api/chat/{session_id}/poll/
     - session_id (path, string (required)): Session ID
     - since (query, string (optional)): Only return messages after this timestamp
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ChatPollResponse
   Security:
@@ -68,7 +68,7 @@ POST /api/chat/{session_id}/upload/
     Content: multipart/form-data
     Schema: ChatUploadFileRequest
   Responses:
-    201: 
+    201:
       Content: application/json
       Schema: ChatUploadFileResponse
   Security:
@@ -82,7 +82,7 @@ POST /api/chat/start/
     Content: application/json
     Schema: ChatStartSessionRequest
   Responses:
-    201: 
+    201:
       Content: application/json
       Schema: ChatStartSessionResponse
   Security:

--- a/docs/api/v1/chatbots.txt
+++ b/docs/api/v1/chatbots.txt
@@ -11,7 +11,7 @@ GET /api/v2/chatbots/
     - cursor (query, string (optional)): The pagination cursor value.
     - page_size (query, integer (optional)): Number of results to return per page.
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: PaginatedChatbotList
   Security:
@@ -25,7 +25,7 @@ GET /api/v2/chatbots/{id}/
   Parameters:
     - id (path, string (required)): Chatbot ID
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: Chatbot
   Security:
@@ -41,7 +41,7 @@ GET /api/v2/chatbots/{id}/inspect/
     - id (path, string (required)): Chatbot ID
     - version (query, string (optional)): Which version to inspect: a version number, 'default' for the default published version, or omit for the working (draft) version.
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ChatbotInspect
   Security:

--- a/docs/api/v1/experiment_sessions.txt
+++ b/docs/api/v1/experiment_sessions.txt
@@ -16,7 +16,7 @@ GET /api/sessions/
     - tags (query, string (optional)): A list of session tags (comma separated) to filter the results by
     - versions (query, string (optional)): Experiment versions (comma separated) to filter sessions by
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: PaginatedExperimentSessionList
   Security:
@@ -31,7 +31,7 @@ POST /api/sessions/
     Content: application/json
     Schema: ExperimentSessionCreate
   Responses:
-    201: 
+    201:
       Content: application/json
       Schema: ExperimentSession
   Security:
@@ -42,14 +42,14 @@ POST /api/sessions/
 
 GET /api/sessions/{id}/
   Summary: Retrieve Chatbot Session
-  Description: 
+  Description:
 Retrieve the details of an session. This includes the messages exchanged during the session ordered
 by the creation date.
 
   Parameters:
     - id (path, string (required)): ID of the session
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ExperimentSessionWithMessages
   Security:
@@ -79,7 +79,7 @@ POST /api/sessions/{id}/tags/
     Content: application/json
     Schema: tags_request_serializer
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: tags_response_serializer
   Security:
@@ -94,7 +94,7 @@ DELETE /api/sessions/{id}/tags/
   Parameters:
     - id (path, string (required)): ID of the session
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: tags_response_serializer
   Security:
@@ -111,7 +111,7 @@ PATCH /api/sessions/{id}/update_state/
     Content: application/json
     Schema: Patchedupdate_state_serializer
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: update_state_response
   Security:

--- a/docs/api/v1/experiments.txt
+++ b/docs/api/v1/experiments.txt
@@ -12,7 +12,7 @@ GET /api/experiments/
     - cursor (query, string (optional)): The pagination cursor value.
     - page_size (query, integer (optional)): Number of results to return per page.
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: PaginatedExperimentList
   Security:
@@ -26,7 +26,7 @@ GET /api/experiments/{id}/
   Parameters:
     - id (path, string (required)): Experiment ID
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: Experiment
   Security:

--- a/docs/api/v1/files.txt
+++ b/docs/api/v1/files.txt
@@ -11,7 +11,7 @@ GET /api/files/{id}/content
   Parameters:
     - id (path, integer (required)): No description
   Responses:
-    200: 
+    200:
       Content: application/octet-stream
       Schema: string
   Security:

--- a/docs/api/v1/me.txt
+++ b/docs/api/v1/me.txt
@@ -9,7 +9,7 @@ GET /api/v2/me/
   Summary: Current User
   Description: Returns basic information about the authenticated user and the team the token is scoped to.
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: Me
   Security:

--- a/docs/api/v1/openai.txt
+++ b/docs/api/v1/openai.txt
@@ -8,7 +8,7 @@ ENDPOINTS:
 
 POST /api/openai/{experiment_id}/chat/completions
   Summary: Chat Completions API for Experiments
-  Description: 
+  Description:
 Use OpenAI's client to send messages to the experiment and get responses. This will
 create a new session in the experiment with all the provided messages
 and return the response from the experiment.
@@ -42,7 +42,7 @@ reply = completion.choices[0].message
     Content: application/json
     Schema: CreateChatCompletionRequest
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: CreateChatCompletionResponse
   Security:
@@ -53,7 +53,7 @@ reply = completion.choices[0].message
 
 POST /api/openai/{experiment_id}/v{version}/chat/completions
   Summary: Versioned Chat Completions API for Experiments
-  Description: 
+  Description:
 Use OpenAI's client to send messages to the experiment and get responses. This will
 create a new session in the experiment with all the provided messages
 and return the response from the experiment.
@@ -89,7 +89,7 @@ reply = completion.choices[0].message
     Content: application/json
     Schema: CreateChatCompletionRequest
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: CreateChatCompletionResponse
   Security:

--- a/docs/api/v1/participants.txt
+++ b/docs/api/v1/participants.txt
@@ -16,7 +16,7 @@ GET /api/participants
     - page_size (query, integer (optional)): Number of results to return per page.
     - platform (query, string (optional)): Filter by platform (e.g. api, telegram, whatsapp)
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: PaginatedParticipantDetailList
   Security:
@@ -32,7 +32,7 @@ POST /api/participants
     Content: application/json
     Schema: ParticipantDataUpdateRequest
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ParticipantDetail
   Security:
@@ -51,7 +51,7 @@ GET /api/participants/
     - page_size (query, integer (optional)): Number of results to return per page.
     - platform (query, string (optional)): Filter by platform (e.g. api, telegram, whatsapp)
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: PaginatedParticipantDetailList
   Security:
@@ -67,7 +67,7 @@ POST /api/participants/
     Content: application/json
     Schema: ParticipantDataUpdateRequest
   Responses:
-    200: 
+    200:
       Content: application/json
       Schema: ParticipantDetail
   Security:

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -43,7 +43,7 @@ You are a friendly assistant. Here's some files that you can attach to your resp
 becomes
 
 ```text
-You are a friendly assitant. Here's some files that you can attach to your responses when you think the user will benefit from it:
+You are a friendly assistant. Here's some files that you can attach to your responses when you think the user will benefit from it:
 * File (id=22, content_type=image/png): This is an image of a border collie
 * File (id=23, content_type=application/pdf): This file contains information about the behaviours of border collies
 ```

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -35,14 +35,14 @@ The location in the prompt where these summaries are included is defined by the 
 
 Here’s an example of how file details appear in the system prompt:
 
-```
+```text
 You are a friendly assistant. Here's some files that you can attach to your responses when you think the user will benefit from it:
 {media}
 ```
 
 becomes
 
-```
+```text
 You are a friendly assitant. Here's some files that you can attach to your responses when you think the user will benefit from it:
 * File (id=22, content_type=image/png): This is an image of a border collie
 * File (id=23, content_type=application/pdf): This file contains information about the behaviours of border collies

--- a/docs/concepts/evaluations/evaluators.md
+++ b/docs/concepts/evaluations/evaluators.md
@@ -15,7 +15,7 @@ For the how-to guide, see [Set Up a Real-Time LLM Judge](../../how-to/evaluation
 
 **Example prompt:**
 
-```
+```text
 Rate the helpfulness and accuracy of this response on a scale of 1-5:
 
 User question: {input.content}

--- a/docs/concepts/pipelines/nodes.md
+++ b/docs/concepts/pipelines/nodes.md
@@ -2,7 +2,7 @@
 
 A node is a discrete processing step in a [pipeline](index.md) that accepts a user’s input and produces an output to downstream nodes. Each node in the pipeline performs a specific task (like calling an LLM, running Python code, or routing based on logic) and processes data that flows through the pipeline.
 
-``` mermaid
+```mermaid
 graph LR
   A@{ shape: stadium, label: "Input (ie data or prompt)" } --> B(Node);
   B --> C@{ shape: stadium, label: "Output (ie LLM response)" };

--- a/docs/concepts/prompt_variables.md
+++ b/docs/concepts/prompt_variables.md
@@ -1,6 +1,6 @@
 Prompt variables are a great way to make your prompt dynamic or tailored to the participant by injecting data into specified placeholders. These variables are predefined and look like this:
 
-```
+```text
 {variable}
 ```
 
@@ -48,7 +48,7 @@ Subsets of the data can be accessed using dot notation. For example, if you have
 
 You can access specific parts of the data using the following prompt variables:
 
-```
+```text
 {participant_data.name}
 {participant_data.address.street}
 {participant_data.tasks[0].name}  # lists are zero-indexed
@@ -58,7 +58,7 @@ You can access specific parts of the data using the following prompt variables:
 
 When using API integrations that pass context with messages, you can access this contextual information in your prompts using the session state variable:
 
-```
+```text
 {session_state.remote_context}
 ```
 
@@ -75,7 +75,7 @@ For example, if an API client sends a message with context like this:
 
 You can access specific values in your prompts:
 
-```
+```text
 Current page: {session_state.remote_context.page_url}
 Product ID: {session_state.remote_context.product_id}
 User segment: {session_state.remote_context.user_segment}

--- a/docs/how-to/add_a_knowledge_base.md
+++ b/docs/how-to/add_a_knowledge_base.md
@@ -12,7 +12,7 @@ To reference the source material, include the `{source_material}` [prompt variab
 
 Example prompt:
 
-```
+```text
 You are a friendly bot. Be sure to reference the source material before answering the user's query:
 
 ### Source material

--- a/docs/how-to/evaluations/realtime_llm_judge.md
+++ b/docs/how-to/evaluations/realtime_llm_judge.md
@@ -43,7 +43,7 @@ In session-level prompts, `{input.content}` and `{output.content}` are empty —
 
 **Example prompt:**
 
-```
+```text
 You are evaluating a support chatbot conversation. Review the session below and assess:
 1. Whether the participant's goal was completed.
 2. The overall quality of the responses.

--- a/docs/how-to/reminders.md
+++ b/docs/how-to/reminders.md
@@ -18,7 +18,7 @@ Reminder tools let your chatbot schedule messages that OCS delivers to participa
 
 Add instructions to your system prompt that name the tools explicitly:
 
-```
+```text
 When the participant asks to be reminded once, use the `one-off-reminder` tool.
 When the participant asks to be recurrently reminded about something, use the `recurring-reminder` tool.
 When they ask to cancel a reminder, use the `delete-reminder` tool.
@@ -27,7 +27,7 @@ When they ask to change the time, use the `move-scheduled-message-date` tool.
 
 Also describe the tone for reminder messages:
 
-```
+```text
 Write reminder messages in a warm, encouraging tone.
 For example: "Good morning! Time to take your medication."
 ```
@@ -41,7 +41,7 @@ The tools handle timezones differently:
 
 If the channel is the web chat widget, the participant's timezone is available as [participant data](../concepts/participant_data.md#participant-timezone-for-web-channel). For other channels, include the timezone in your system prompt:
 
-```
+```text
 Participants are in Cape Town, South Africa (UTC+2). When calling move-scheduled-message-date, convert their requested local time to UTC.
 ```
 

--- a/docs/how-to/routers/index.md
+++ b/docs/how-to/routers/index.md
@@ -27,7 +27,7 @@ To understand how users move through your chatbot, you can enable Output Message
 ### Tag naming convention
 To keep system tags organized, OCS follows this naming convention:
 
-```
+```text
 <node_name>:<route_name>
 ```
 

--- a/docs/how-to/whatsapp_meta_cloud_api.md
+++ b/docs/how-to/whatsapp_meta_cloud_api.md
@@ -222,7 +222,7 @@ To update the language code:
 
 Open Chat Studio uses a **single global webhook endpoint** for all Meta Cloud API channels:
 
-```
+```text
 https://openchatstudio.com/api/channels/meta/incoming_message
 ```
 

--- a/docs/how-to/whatsapp_meta_cloud_api.md
+++ b/docs/how-to/whatsapp_meta_cloud_api.md
@@ -222,7 +222,7 @@ To update the language code:
 
 Open Chat Studio uses a **single global webhook endpoint** for all Meta Cloud API channels:
 
-```text
+```uri
 https://openchatstudio.com/api/channels/meta/incoming_message
 ```
 

--- a/docs/how-to/workflow_cookbook.md
+++ b/docs/how-to/workflow_cookbook.md
@@ -66,7 +66,7 @@ def main(input, **kwargs):
 
 Then in the LLM node prompt you could use the [**temp_state**][prompt_vars] to inject the category:
 
-```
+```text
 The current category is {temp_state.category}
 ```
 
@@ -143,7 +143,7 @@ Configure your LLM node to utilize the uploaded file contents by injecting them 
 
 *Basic Prompt Template:*
 
-```
+```text
 You are a helpful assistant. Answer the user's query as best you can.
 
 Here are some file contents that you should consider when generating your answer:

--- a/docs/how-to/workflow_cookbook.md
+++ b/docs/how-to/workflow_cookbook.md
@@ -8,7 +8,7 @@ In such cases, it can be better to create smaller, narrowly focused prompts and 
 
 Here is a more complex example that uses a [LLM Router][router] to route the input to one of three linked nodes.
 
-``` mermaid
+```mermaid
 graph TB
   A@{ shape: stadium, label: "Input" } --> Router("`**LLM Router**
   Route to one of the linked nodes using an LLM`");

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ deploying chatbots powered by Large Language Models ([LLMs](concepts/llm.md)).
   your
   chatbots.
 
-* **View and Download Data:** View and export the data from interactions [(ie Tracing)](concepts/tracing.md) with your chatbots, formatted In CSV.
+* **View and Download Data:** View and export the data from interactions with your chatbots, formatted In CSV.
 
 <div class="grid cards" markdown>
 

--- a/docs/tech-hub/evaluations/dataset-structure.md
+++ b/docs/tech-hub/evaluations/dataset-structure.md
@@ -52,7 +52,7 @@ The `input` and `output` fields are empty for session-level rows. Evaluators wor
 
 When adding history manually in the UI or as a column in a CSV, history must be a newline-separated list of messages, each prepended with either `user:` or `assistant:`. For example:
 
-```
+```text
 user: Hello, how are you?
 assistant: I am doing well, thank you for asking. How can I help you?
 user: Please tell me the time.

--- a/docs/tech-hub/external-api-calls/index.md
+++ b/docs/tech-hub/external-api-calls/index.md
@@ -69,7 +69,7 @@ Weather Forecast:
 
 **LLM Prompt Configuration:**
 
-```
+```text
 You are a helpful weather assistant. Use the weather data provided to answer the user's question.
 
 {temp_state.weather_data}
@@ -156,7 +156,7 @@ def main(input, **kwargs) -> str:
 
 **LLM Prompt Configuration:**
 
-```
+```text
 You are a product support assistant.
 
 {% if temp_state.product_error %}

--- a/docs/tech-hub/python_node.md
+++ b/docs/tech-hub/python_node.md
@@ -84,7 +84,7 @@ The Python node provides an `http` global that enables secure HTTP requests to e
 ## Temporary State
 The Python node can also access and modify the temporary state of the pipeline. The temporary state is a dictionary that is unique to each run of the pipeline (each new message from the user) and is not stored between sessions.
 
-The temporary state can be accessed and modified using the [get_temp_state_key](#python_node.get_temp_state_key) and [set_temp_state_key](#python_node.set_temp_state_key) utility functions.
+The temporary state can be accessed and modified using the [get_temp_state_key](#python_node.get_temp_state_key) and [set_temp_state_key](#python_node.set_temp_state_key) utility functions. <!-- markdownlint-disable-line MD051 -->
 
 Temporary state contains the following keys by default. These keys can not be modified or deleted:
 
@@ -114,7 +114,7 @@ Here is an example of a temporary state dictionary:
 ## Session State
 The Python node can also access and modify the state of the participant's session. This state is a dictionary that is scoped to each session that the user might have with the bot.
 
-The session state can be accessed and modified using the [get_session_state_key](#python_node.get_session_state_key) and [set_session_state_key](#python_node.set_session_state_key) utility functions.
+The session state can be accessed and modified using the [get_session_state_key](#python_node.get_session_state_key) and [set_session_state_key](#python_node.set_session_state_key) utility functions. <!-- markdownlint-disable-line MD051 -->
 
 ## Attachments
 

--- a/docs/tech-hub/python_node.md
+++ b/docs/tech-hub/python_node.md
@@ -29,7 +29,7 @@ The following additional arguments are provided:
 
     All code must be encapsulated in a `main` function. You can write other functions but they must be within the scope of the `main` function. For example:
 
-    ``` py
+    ```python
     def main(input, **kwargs):
         def important(arg):
             return arg + "!"

--- a/docs/tech-hub/tools.md
+++ b/docs/tech-hub/tools.md
@@ -36,7 +36,7 @@ To instruct the model to use a specific tool, refer to it by its tool name in yo
 | OpenAI | [Code Interpreter](#openai-code-interpreter) | :material-check-circle-outline:{ .green } Yes |
 | Anthropic | [Web Search](#anthropic-web-search) | :material-check-circle-outline:{ .green } Yes |
 | Anthropic | [Code Execution](#anthropic-code-execution) | :octicons-x-circle-24:{ .red } No |
-| Gemini | [Grounding with Search](#gemini-web-search) | :octicons-x-circle-24:{ .red } No |
+| Gemini | [Grounding with Search](#gemini-grounding-with-search) | :octicons-x-circle-24:{ .red } No |
 | Gemini | [Code Execution](#gemini-code-execution) | :octicons-x-circle-24:{ .red } No |
 
 ## User-configurable tools
@@ -190,13 +190,13 @@ Some LLM providers offer their own built-in tools that run inside the provider's
 
 ### OpenAI tools
 
-#### Web Search { #openai-web-search }
+#### OpenAI Web Search
 
 - Search the web and pass the results to the LLM.
 - See [OpenAI Web Search documentation](https://platform.openai.com/docs/guides/tools-web-search)
 - :material-check-circle-outline:{ .green } Supported by OCS
 
-#### Code Interpreter { #openai-code-interpreter }
+#### OpenAI Code Interpreter
 
 - Execute code to analyse data, generate graphs, and more.
 - See [OpenAI Code Interpreter documentation](https://platform.openai.com/docs/guides/tools-code-interpreter)
@@ -204,13 +204,13 @@ Some LLM providers offer their own built-in tools that run inside the provider's
 
 ### Anthropic tools
 
-#### Web Search { #anthropic-web-search }
+#### Anthropic Web Search
 
 - Search the web and pass the results to the LLM.
 - See [Anthropic Web Search documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool)
 - :material-check-circle-outline:{ .green } Supported by OCS
 
-#### Code Execution { #anthropic-code-execution }
+#### Anthropic Code Execution
 
 - Execute code to analyse data, generate graphs, and more.
 - See [Anthropic Code Execution documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/code-execution-tool)
@@ -218,13 +218,13 @@ Some LLM providers offer their own built-in tools that run inside the provider's
 
 ### Gemini tools
 
-#### Grounding with search { #gemini-web-search }
+#### Gemini Grounding with Search
 
 - Search the web and pass the results to the LLM.
 - See [Gemini Grounding with Search documentation](https://ai.google.dev/gemini-api/docs/google-search)
 - :octicons-x-circle-24:{ .red } Not supported by OCS
 
-#### Code Execution { #gemini-code-execution }
+#### Gemini Code Execution
 
 - Execute code to analyse data, generate graphs, and more.
 - See [Gemini Code Execution documentation](https://ai.google.dev/gemini-api/docs/code-execution)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "prek>=0.4.5",
+    "pytest>=9.1.1",
 ]
 
 [tool.uv]

--- a/scripts/tests/test_openapi_to_docs.py
+++ b/scripts/tests/test_openapi_to_docs.py
@@ -156,6 +156,22 @@ def test_inject_versions_list_reversed_markers_raises(tmp_path):
         inject_versions_list(index_path, ["v1"])
 
 
+def test_response_empty_description_emits_no_trailing_space():
+    converter = OpenAPIToMarkdownConverter(
+        {"openapi": "3.0.0", "info": {"title": "T", "version": "1"}, "paths": {}}
+    )
+
+    lines = converter._generate_endpoint_section_minified(
+        "delete", "/api/x/", {"responses": {"204": {"description": ""}, "200": {}}}
+    )
+
+    assert "    204:" in lines
+    assert "    200:" in lines
+    # Neither code must have a trailing space
+    assert "    204: " not in lines
+    assert "    200: " not in lines
+
+
 def test_endpoint_security_handles_optional_requirement():
     # An empty requirement object ({}) means auth is optional; it must not crash.
     schema = {

--- a/src/ocs_docs/openapi_to_docs.py
+++ b/src/ocs_docs/openapi_to_docs.py
@@ -386,8 +386,17 @@ class OpenAPIToMarkdownConverter:
         if responses:
             lines.append("  Responses:")
             for status_code, response in responses.items():
-                description = response.get("description", "No description")
-                lines.append(f"    {status_code}: {description}")
+                # Only show the description when it's provided; otherwise emit just the code and colon.
+                description = response.get("description", "")
+                if isinstance(description, str):
+                    description = description.strip()
+                else:
+                    description = str(description)
+
+                if description:
+                    lines.append(f"    {status_code}: {description}")
+                else:
+                    lines.append(f"    {status_code}:")
 
                 content = response.get("content", {})
                 for media_type, media_content in content.items():

--- a/uv.lock
+++ b/uv.lock
@@ -130,6 +130,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "prek" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -330,7 +340,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "prek", specifier = ">=0.4.5" }]
+dev = [
+    { name = "prek", specifier = ">=0.4.5" },
+    { name = "pytest", specifier = ">=9.1.1" },
+]
 
 [[package]]
 name = "packaging"
@@ -357,6 +370,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -426,6 +448,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Background

Added pre-commit hooks recently with markdown lint checks. Some checks disabled as needed to make fixes to existing files

1. Enabled rule 40 - lint checking for code fence language tags & fixed "text" language tags
2. Enabled markdown lint rule 51 -for checking link fragments are be valid: it warns when a link's fragment (the part after #) doesn't match any heading anchor generated for the document
3. Removed extra spaces on some files

**Fixed generation of API docs**

5. Updated openapi_to_docs.py so that it does not put spaces in API .txt files that get caught in pre-commits. This .py is called from GitHub action - update-api-docs.yml
 - Added a new test case for the above change
 - Added pytest to the dependencies as this was missing


### Acceptance Testing

For new test case to create API docs run
`uv run pytest scripts/tests/test_openapi_to_docs.py -v 2>&1`

Generate API docs with GitHub action: Update API Documentation