### PR TITLE
Add monthly changelog compaction workflow

### DIFF
--- a/.github/templates/changelog-compaction-instructions.md
+++ b/.github/templates/changelog-compaction-instructions.md
@@ -12,7 +12,8 @@ single summary per month.
 
 For each calendar month earlier than the cutoff, replace all of its per-day sections
 (e.g. `## May 18, 2026`, `## May 15, 2026`, …) with a **single** section headed by the
-month and year only:
+month and year only. Use the **abbreviated month** form to match the file's existing
+day headings (`## Jun 22, 2026` → `## Jun 2026`, `## Apr 8, 2026` → `## Apr 2026`):
 
 ```
 ## May 2026

--- a/.github/templates/changelog-compaction-instructions.md
+++ b/.github/templates/changelog-compaction-instructions.md
@@ -1,0 +1,41 @@
+You are compacting the Open Chat Studio changelog at `${CHANGELOG_FILE}` to keep its
+length manageable. Recent history stays verbatim; older history is condensed into a
+single summary per month.
+
+## Retention rule
+
+- **Keep verbatim** every entry dated on or after **${CUTOFF_HUMAN}**. These are the
+  three most recent months (${KEEP_MONTHS}) — do not touch their headings or bullets.
+- **Summarize** every entry dated *before* **${CUTOFF_HUMAN}**.
+
+## How to summarize an older month
+
+For each calendar month earlier than the cutoff, replace all of its per-day sections
+(e.g. `## May 18, 2026`, `## May 15, 2026`, …) with a **single** section headed by the
+month and year only:
+
+```
+## May 2026
+```
+
+Under that heading, write a concise summary (typically 1–4 sentences, prose) of what
+changed that month. Guidelines:
+
+- Lead with the most significant user-facing changes (new features, behaviour changes).
+- Group related items rather than listing every bullet.
+- **Always preserve** breaking changes, deprecations, removal/sunset dates, and
+  `**MIGRATION**` notes explicitly — these must not be lost in summarization.
+- Match the existing tone: active voice, user-facing framing, no internal detail.
+- Keep meaningful inline links (e.g. to deprecation successors or guides) where they
+  add value.
+
+## Hard constraints
+
+- Preserve the YAML frontmatter, the `# Changelog` title, the `!!! info` admonition, and
+  the trailing `---` plus the "older entries … GitHub release notes" footer line exactly.
+- Keep all sections in reverse chronological order (newest first).
+- **Idempotency:** a month already collapsed to a `## <Month> <Year>` heading (no day in
+  the heading) is already summarized — leave it unchanged. Only collapse months that
+  still have per-day sections and fall before the cutoff.
+- Edit **only** `${CHANGELOG_FILE}`. Do not create a commit or a pull request — the
+  workflow handles that.

--- a/.github/workflows/compact-changelog.yml
+++ b/.github/workflows/compact-changelog.yml
@@ -1,0 +1,110 @@
+# Workflow: Compact Changelog
+#
+# Runs on the 1st of every month. Keeps the three most recent months of the changelog
+# verbatim and collapses each older month into a single summary section (written by
+# Claude), then opens a PR with the result.
+
+name: Compact Changelog
+
+on:
+  schedule:
+    - cron: '0 3 1 * *'  # 03:00 UTC on the 1st of every month
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  compact-changelog:
+    runs-on: ubuntu-latest
+    env:
+      CHANGELOG_FILE: docs/changelog.md
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OCS_AGENT_APP_ID }}
+          private-key: ${{ secrets.OCS_AGENT_PRIVATE_KEY }}
+          owner: dimagi
+          repositories: open-chat-studio-docs
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Compute retention window
+        id: window
+        run: |
+          set -euo pipefail
+          # Anchor to the first of the current month so the relative subtraction below
+          # can't skip a month (e.g. Mar 31 minus one month). The three months kept
+          # verbatim are the current month plus the two before it.
+          FIRST=$(date -u +%Y-%m-01)
+          CUTOFF=$(date -u -d "$FIRST -2 months" +%Y-%m-%d)
+          CUTOFF_HUMAN=$(date -u -d "$CUTOFF" +'%b %-d, %Y')
+          M0=$(date -u -d "$FIRST" +'%b %Y')
+          M1=$(date -u -d "$FIRST -1 month" +'%b %Y')
+          M2=$(date -u -d "$FIRST -2 months" +'%b %Y')
+          echo "cutoff_human=$CUTOFF_HUMAN" >> "$GITHUB_OUTPUT"
+          echo "keep_months=$M0, $M1, $M2" >> "$GITHUB_OUTPUT"
+          echo "Keeping verbatim: $M0, $M1, $M2 (cutoff: $CUTOFF_HUMAN)"
+
+      - name: Build Claude prompt
+        id: prompt
+        env:
+          CUTOFF_HUMAN: ${{ steps.window.outputs.cutoff_human }}
+          KEEP_MONTHS: ${{ steps.window.outputs.keep_months }}
+        run: |
+          set -euo pipefail
+          {
+            echo "instructions<<EOF"
+            envsubst < .github/templates/changelog-compaction-instructions.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code to compact the changelog
+        id: claude
+        timeout-minutes: 10
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: ${{ steps.prompt.outputs.instructions }}
+          claude_args: |
+            --allowedTools "Read,Edit"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [ -z "$(git status --porcelain "$CHANGELOG_FILE")" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No compaction needed this month."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "compact changelog: summarize entries older than ${{ steps.window.outputs.cutoff_human }}"
+          title: "Compact changelog (keep ${{ steps.window.outputs.keep_months }} verbatim)"
+          body: |
+            ## Summary
+            Automated monthly changelog compaction. Entries from the three most recent
+            months (${{ steps.window.outputs.keep_months }}) are kept verbatim; older
+            months are collapsed into a single summary section each.
+
+            Please review the generated summaries before merging.
+          branch: compact-changelog-${{ github.run_number }}
+          delete-branch: true
+          assignees: snopoke
+          team-reviewers: dimagi/open-chat-studio
+          labels: automated

--- a/.github/workflows/compact-changelog.yml
+++ b/.github/workflows/compact-changelog.yml
@@ -14,7 +14,11 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
+
+# A manual dispatch must not overlap the scheduled run and open a second PR.
+concurrency:
+  group: compact-changelog
+  cancel-in-progress: false
 
 jobs:
   compact-changelog:
@@ -82,6 +86,7 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
+          set -euo pipefail
           if [ -z "$(git status --porcelain "$CHANGELOG_FILE")" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No compaction needed this month."
@@ -103,6 +108,7 @@ jobs:
             months are collapsed into a single summary section each.
 
             Please review the generated summaries before merging.
+          add-paths: docs/changelog.md
           branch: compact-changelog-${{ github.run_number }}
           delete-branch: true
           assignees: snopoke


### PR DESCRIPTION
Adds a scheduled workflow (1st of each month, plus manual dispatch) that keeps the changelog from growing unbounded: the three most recent months stay verbatim, and each older month is collapsed into a single Claude-written summary section. Opens a PR with the result rather than committing directly, so the summaries get reviewed.

Mirrors the existing `update-changelog` / `update-api-docs` workflows for token, PR, and template conventions; Claude is restricted to `Read,Edit` on `docs/changelog.md`.

Worth a look:
- The instruction template (`changelog-compaction-instructions.md`) forces breaking changes / deprecations / sunset dates / `**MIGRATION**` notes to survive summarization, and is idempotent (already-collapsed months are left alone).
- Only the main changelog is compacted — `docs/chat_widget/changelog.md` is untouched.
- The **first** run will produce a large diff (everything before the cutoff summarized at once), so the initial PR needs a careful read.