### PR TITLE
Split out advanced topics from Concepts->Indexed Collections

### DIFF
--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -1,39 +1,37 @@
 # Collections
 
-!!! info "Collections are only supported with pipeline bots"
-
 A collection in OCS refers to a collection of files. There are two types of collections:
 
 - [Media collection](./media.md)
 - [Indexed Collection (for RAG applications)](./indexed.md)
 
-## Adding a collection to a bot
+## Adding a collection to a chatbot
 
 Navigate to the **Collections** section in the sidebar and click "Add new". Once the collection is created, you will be able to upload files to it.
 
 After your collection has been created and populated with files, you can link it to any [LLM node][llm_node].
 
-## Collections and published bots
+## Collections and published chatbots
 
-Collection content is a **live shared resource**. When you update the files in a collection — either manually or through a scheduled document-source sync — those changes are reflected in your published bot automatically. You do not need to republish to pick up new or updated files.
+Collection content is a **live shared resource**. When you update the files in a collection — either manually or through a scheduled document-source sync — those changes are reflected in your published chatbot automatically. You do not need to republish to pick up new or updated files.
 
 This means:
 
 - Adding or removing files from a media collection takes effect for users immediately.
-- Document-source syncs to a RAG index collection (for example, nightly Confluence or GitHub syncs) are applied to the published bot as each sync completes.
+- Document-source syncs to a RAG index collection (for example, nightly Confluence or GitHub syncs) are applied to the published chatbot as each sync completes.
 
-The *structure* of a published version — which collections are linked to which pipeline nodes — is still frozen at publish time. To change which collections a bot uses, you must publish a new version.
+The *structure* of a published version — which collections are linked to which pipeline nodes — is still frozen at publish time. To change which collections a chatbot uses, you must publish a new version.
 
 For more detail on how versioning interacts with collections, see [Versioning](../versioning.md#what-is-frozen-and-what-is-live).
 
 ## How are attachments sent?
-Whenever your bot references a particular file or document, it will be sent to the user as an attachment. Depending on the channel, attachments are delivered in different ways.
+Whenever your chatbot references a particular file or document, it will be sent to the user as an attachment. Depending on the channel, attachments are delivered in different ways.
 
 ### Web channels
 Attachments are directly downloadable by clicking on them.
 
 ### Multimedia-unsupported channels
-By default, attachments are sent as download links appended to the bot's message. The user will see the file name and a corresponding download link at the end of the message. These channels do not yet support sending multimedia files:
+By default, attachments are sent as download links appended to the chatbot's message. The user will see the file name and a corresponding download link at the end of the message. These channels do not yet support sending multimedia files:
 
 * Telegram
 * WhatsApp (Turn.io provider)
@@ -42,7 +40,7 @@ By default, attachments are sent as download links appended to the bot's message
 * Slack
 
 ### Multimedia-supported channels
-Channels that support sending multimedia files will receive each attachment as a separate message, following the bot's initial response. If a file type is not supported by the channel, or the file size exceeds the allowed limit, a download link will be appended to the bot's message instead. These channels support sending multimedia files:
+Channels that support sending multimedia files will receive each attachment as a separate message, following the chatbot's initial response. If a file type is not supported by the channel, or the file size exceeds the allowed limit, a download link will be appended to the chatbot's message instead. These channels support sending multimedia files:
 
 * API - See the [API documentation](https://openchatstudio.com/api/v1/docs/#tag/Channels/operation/new_api_message) for more information
 * WhatsApp (Twilio Provider) - Consult the [Twilio docs][twilio_docs] for supported file types.

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -27,7 +27,7 @@ To search documents by meaning, OCS uses an **embedding model** — a component 
 
 In OCS, there are two types of indexes:
 
-- Remote Index
+- [Remote Index](#remote-index)
 - Local Index
 
 ### Which should I use?
@@ -91,63 +91,11 @@ For advanced configuration — including chunk size, chunk overlap, and embeddin
 
 ## Document Sources
 
-In addition to manually uploading documents to a collection, you can also configure document sources from which Open Chat Studio will automatically load and index documents.
-
-The primary advantage of document sources over manual uploads is that Open Chat Studio can check for updates periodically, which eliminates the need for manual updates.
+Instead of uploading files manually, you can connect OCS to an external source — such as a Confluence space or GitHub repository — and have it fetch and index content automatically on a schedule. This keeps your collection current without manual uploads.
 
 !!! note "Document-source updates reach published chatbots automatically"
-    When a document-source sync runs and updates the collection's content, those changes are applied to your published chatbot without requiring a republish. See [Collections and published bots](./index.md#collections-and-published-bots) for more detail.
+    When a document-source sync runs and updates the collection's content, those changes are applied to your published chatbot without requiring a republish. See [Collections and published chatbots](./index.md#collections-and-published-chatbots) for more detail.
 
-The following document source types are currently supported:
+Currently supported sources: **Confluence** and **GitHub**.
 
-### :simple-confluence: Confluence
-
-Load pages from a Confluence site. Pages can be filtered using the space key, label, CQL, or individual page IDs.
-
-**Authentication**
-
-Use a [Basic Auth](../team/authentication_providers.md#basic-auth) authentication provider with your Atlassian username and use your API Key as the password.
-
-**Configuration**
-
-| Field     | Description                                                               |
-|-----------|---------------------------------------------------------------------------|
-| Site URL  | The URL of the Confluence site (e.g. https://yoursite.atlassian.net/wiki) |
-| Max Pages | The maximum number of pages to load                                       |
-| Space Key | Load pages from this space                                                |
-| Label     | Load pages with this label                                                |
-| CQL       | CQL query to use to search for pages to load                              |
-| Page IDs  | Load only these specific pages                                            |
-
-!!! note
-
-    Only one of the `Space Key`, `Label`, `CQL` and `Page IDs` fields can be used at a time.
-
-### :simple-github: GitHub
-
-Load pages from a GitHub repository. Files can be filtered by path and by matching patterns against the filenames.
-
-**Authentication**
-
-Use a [Bearer Token](../team/authentication_providers.md#bearer-token) authentication provider.
-
-**Configuration**
-
-| Field          | Description                                                          |
-|----------------|----------------------------------------------------------------------|
-| Repository URL | GitHub repository URL (e.g. https://github.com/user/repo)            |
-| Branch         | Git branch to sync from                                              |
-| File Pattern   | File patterns to include. Prefix with '!' to exclude matching files. |
-| Path Filter    | Optional path prefix to filter files (e.g., docs/)                   |
-
-## Monitoring Sync Status
-
-Open Chat Studio tracks the history of every sync run for each document source. Use the sync logs to confirm that syncs are completing successfully and to diagnose problems when they are not.
-
-### Status indicator
-
-Each document source header displays a status indicator reflecting the outcome of the most recent sync:
-
-- **Error** – the last sync encountered a problem. The indicator is shown in red.
-- **Success** – the last sync completed without errors.
-- **In progress** – a sync is currently running. The indicator animates to show activity.
+For configuration steps, authentication setup, and how to monitor sync status, see [Set Up Document Sources](../../how-to/document_sources.md).

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -19,7 +19,7 @@ Common examples include:
 !!! note "Definition"
     **Retrieval-Augmented Generation** (RAG) is a technique where a language model retrieves relevant information from a set of documents to ground its answers in real data. Instead of relying solely on its built-in knowledge, the model uses indexes—specialized databases that store document content as vectors (numerical representations of meaning). This makes it easy for the model to find and use the most relevant parts of your uploaded files when answering questions.
 
-To search documents by meaning, OCS uses an **embedding model** — a component that converts text into a mathematical form so the chatbot can find conceptually related content even when the exact words don't match. For example, a user asking "how do I cancel?" can match a document that says "terminating your subscription."
+To search documents by meaning, OCS uses an **embedding model** to convert text into a mathematical form that captures meaning, not just keywords. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md) for a full explanation.
 
 !!! warning "Indexed collections will replace OpenAI Assistants' file search functionality in the future"
 
@@ -64,7 +64,7 @@ Supported files are determined by the selected provider:
 ## Local Index
 !!! info "Local indexes are actively developed. We are working to support additional file types and embedding models so you can better customize your index."
 
-Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [RAG Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
+Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
 
 ### Supported providers
 - OpenAI
@@ -79,10 +79,10 @@ Local indexes are hosted and managed by OCS. When you create a local index, you 
 ### Supported embedding models
 You can see the supported embedding models for each provider when creating or editing the provider in your team settings.
 
-## Chunking and Optimization
-When you upload a document, OCS breaks it into smaller parts called **chunks** and stores them in the index. The default chunking settings work well for most use cases.
+## Chunking and Optimization (Local Indexes only)
+When you upload a document to a local index, OCS breaks it into smaller parts called **chunks** and stores them in the index. The default chunking settings work well for most use cases.
 
-For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Index Optimization](../../tech-hub/local-index-optimization.md).
+For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md).
 
 [file-search]: ../experiment/index.md#file-search
 [migration-guide]: ../../how-to/assistants_migration.md

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -52,7 +52,7 @@ Supported files are determined by the selected provider:
 ## Local Index
 !!! info "Local indexes are a new feature in OCS. We are actively working to support additional file types and embedding models, allowing you to better customize your index with models that suit your needs."
 
-Local indexes are hosted and managed by OCS. When you create a local index, you can select which embedding model to use for generating file embeddings. Embedding models are provided by LLM providers. Just as different LLM models have varying strengths and weaknesses, different embedding models also have their own strengths and weaknesses. Thus, choosing the right embedding model is important to ensure the best performance for your specific use case.
+Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different content types for a chatbot, so choosing the right one can improve retrieval accuracy. See [RAG Index Optimization](../../tech-hub/rag-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
 
 ### Supported providers
 - OpenAI
@@ -68,16 +68,9 @@ Local indexes are hosted and managed by OCS. When you create a local index, you 
 You can see the supported embedding models for each provider when creating or editing the provider in your team settings.
 
 ## Chunking and Optimization
-When you upload a document to an index, it’s broken up into smaller parts called chunks. These chunks are then converted into vectors and stored in the index. Chunking is a key part of how RAG works, as it affects how accurately the model can retrieve relevant information.
+When you upload a document, OCS breaks it into smaller parts called **chunks** and stores them in the index. The default chunking settings work well for most use cases.
 
-In most cases, it will not be necessary to change the default chunking strategy, but you’ll have the option to customize the chunking strategy for each set of uploaded files:
-
-- Chunk size – how large each chunk is (in tokens)
-- Chunk overlap – how much each chunk overlaps with the next, to preserve context
-
-Choosing the right chunking strategy can improve retrieval accuracy, especially for technical documents.
-
-!!! info "This flexibility helps tailor the index to your use case—whether it’s short notes or long, complex reports."
+For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Index Optimization](../../tech-hub/rag-optimization.md).
 
 [file-search]: ../experiment/index.md#file-search
 [migration-guide]: ../../how-to/assistants_migration.md

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -14,23 +14,23 @@ Common examples include:
 - A **research tool** that searches across uploaded reports, studies, or reference materials
 - An **onboarding guide** that walks new users through your own uploaded training content
 
+## How it works
+
 !!! note "Definition"
     **Retrieval-Augmented Generation** (RAG) is a technique where a language model retrieves relevant information from a set of documents to ground its answers in real data. Instead of relying solely on its built-in knowledge, the model uses indexes—specialized databases that store document content as vectors (numerical representations of meaning). This makes it easy for the model to find and use the most relevant parts of your uploaded files when answering questions.
 
+To search documents by meaning, OCS uses an **embedding model** — a component that converts text into a mathematical form so the chatbot can find conceptually related content even when the exact words don't match. For example, a user asking "how do I cancel?" can match a document that says "terminating your subscription."
+
 !!! warning "Indexed collections will replace OpenAI Assistants' file search functionality in the future"
 
-    Consult the [migration guide][migration-guide] if you have assistants that you want to replace with indexed collections.
+    If you've used the OpenAI Assistants' [file search][file-search] capability in OCS, you've already interacted with an index behind the scenes. Consult the [migration guide][migration-guide] if you have assistants you want to replace with indexed collections.
 
-If you’ve used the OpenAI Assistants’ [file search][file-search] capability in OCS, you’ve already interacted with an index behind the scenes.
-
-To search documents by meaning, OCS uses an **embedding model** — a component that converts text into a mathematical form so the chatbot can find conceptually related content even when the exact words don't match. For example, a user asking "how do I cancel?" can match a document that says "terminating your subscription."
+## Which should I use?
 
 In OCS, there are two types of indexes:
 
 - [Remote Index](#remote-index)
-- Local Index
-
-### Which should I use?
+- [Local Index](#local-index)
 
 | | Remote Index | Local Index |
 |---|---|---|
@@ -40,10 +40,10 @@ In OCS, there are two types of indexes:
 | **Collections per LLM node** | Max 2 (OpenAI limit) | Unlimited |
 | **Best for** | Getting started quickly | More control, or more than 2 collections |
 
-If you are new to indexed collections, start with a **Remote Index**. Switch to a Local Index if you need to use more than 2 collections, or want to choose a specific embedding model for your content type.
+If you are new to indexed collections, start with a **Remote Index**. Switch to a Local Index if you need more than 2 collections or want to choose a specific embedding model for your content type.
 
 ## Remote Index
-Remote indexes are hosted and managed by an LLM provider. Files and index configuration are uploaded to the provider, which maintains and manages the index. The embedding model used to create file embeddings is selected by the provider.
+Remote indexes are hosted and managed by your LLM provider. Files are uploaded to the provider, which handles all indexing. The embedding model is chosen by the provider.
 
 ### Supported providers
 - OpenAI (using the [responses API](https://platform.openai.com/docs/api-reference/responses))
@@ -56,17 +56,15 @@ Remote indexes are hosted and managed by an LLM provider. Files and index config
     - **Non-OpenAI providers** are NOT affected by this limit
     - If you attempt to select more than 2 remote collections with OpenAI, you will receive a validation error
 
-    If you need to use more than 2 collections, consider using local indexes instead.
-
 ### Supported file types
 Supported files are determined by the selected provider:
 
 - OpenAI - See the [OpenAI docs](https://platform.openai.com/docs/assistants/tools/file-search/supported-files#supported-files)
 
 ## Local Index
-!!! info "Local indexes are a new feature in OCS. We are actively working to support additional file types and embedding models, allowing you to better customize your index with models that suit your needs."
+!!! info "Local indexes are actively developed. We are working to support additional file types and embedding models so you can better customize your index."
 
-Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different content types for a chatbot, so choosing the right one can improve retrieval accuracy. See [RAG Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
+Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [RAG Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
 
 ### Supported providers
 - OpenAI

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -3,7 +3,7 @@ title: Indexed Collection (for RAG applications)
 ---
 
 ## When should I use this?
-When you want your bot's responses to be grounded in your uploaded documents.
+When you want your chatbot's responses to be grounded in your uploaded documents.
 
 !!! note "Definition"
     **Retrieval-Augmented Generation** (RAG) is a technique where a language model retrieves relevant information from a set of documents to ground its answers in real data. Instead of relying solely on its built-in knowledge, the model uses indexes—specialized databases that store document content as vectors (numerical representations of meaning). This makes it easy for the model to find and use the most relevant parts of your uploaded files when answering questions.
@@ -79,8 +79,8 @@ In addition to manually uploading documents to a collection, you can also config
 
 The primary advantage of document sources over manual uploads is that Open Chat Studio can check for updates periodically, which eliminates the need for manual updates.
 
-!!! note "Document-source updates reach published bots automatically"
-    When a document-source sync runs and updates the collection's content, those changes are applied to your published bot without requiring a republish. See [Collections and published bots](./index.md#collections-and-published-bots) for more detail.
+!!! note "Document-source updates reach published chatbots automatically"
+    When a document-source sync runs and updates the collection's content, those changes are applied to your published chatbot without requiring a republish. See [Collections and published bots](./index.md#collections-and-published-bots) for more detail.
 
 The following document source types are currently supported:
 
@@ -105,7 +105,7 @@ Use a [Basic Auth](../team/authentication_providers.md#basic-auth) authenticatio
 
 !!! note
 
-    Only one of the `Space Key`, `Lable`, `CQL` and `Page IDs` fields can be used at a time.
+    Only one of the `Space Key`, `Label`, `CQL` and `Page IDs` fields can be used at a time.
 
 ### :simple-github: GitHub
 

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -2,8 +2,17 @@
 title: Indexed Collection (for RAG applications)
 ---
 
+An indexed collection lets your chatbot search through your documents to find relevant information before responding. Instead of relying on the AI's built-in knowledge, the chatbot retrieves answers from files you upload — such as PDFs, reports, or wiki pages.
+
 ## When should I use this?
 When you want your chatbot's responses to be grounded in your uploaded documents.
+
+Common examples include:
+
+- A **customer support chatbot** that answers questions from your product documentation or FAQs
+- An **HR assistant** that looks up company policies from an internal wiki or handbook
+- A **research tool** that searches across uploaded reports, studies, or reference materials
+- An **onboarding guide** that walks new users through your own uploaded training content
 
 !!! note "Definition"
     **Retrieval-Augmented Generation** (RAG) is a technique where a language model retrieves relevant information from a set of documents to ground its answers in real data. Instead of relying solely on its built-in knowledge, the model uses indexes—specialized databases that store document content as vectors (numerical representations of meaning). This makes it easy for the model to find and use the most relevant parts of your uploaded files when answering questions.

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -30,6 +30,18 @@ In OCS, there are two types of indexes:
 - Remote Index
 - Local Index
 
+### Which should I use?
+
+| | Remote Index | Local Index |
+|---|---|---|
+| **Managed by** | Your LLM provider (e.g. OpenAI) | OCS |
+| **Setup** | Simpler — the provider handles everything | More steps — you choose the embedding model |
+| **Embedding model** | Selected by the provider | You choose |
+| **Collections per LLM node** | Max 2 (OpenAI limit) | Unlimited |
+| **Best for** | Getting started quickly | More control, or more than 2 collections |
+
+If you are new to indexed collections, start with a **Remote Index**. Switch to a Local Index if you need to use more than 2 collections, or want to choose a specific embedding model for your content type.
+
 ## Remote Index
 Remote indexes are hosted and managed by an LLM provider. Files and index configuration are uploaded to the provider, which maintains and manages the index. The embedding model used to create file embeddings is selected by the provider.
 

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -54,7 +54,7 @@ Supported files are determined by the selected provider:
 ## Local Index
 !!! info "Local indexes are a new feature in OCS. We are actively working to support additional file types and embedding models, allowing you to better customize your index with models that suit your needs."
 
-Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different content types for a chatbot, so choosing the right one can improve retrieval accuracy. See [RAG Index Optimization](../../tech-hub/rag-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
+Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different content types for a chatbot, so choosing the right one can improve retrieval accuracy. See [RAG Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
 
 ### Supported providers
 - OpenAI
@@ -72,7 +72,7 @@ You can see the supported embedding models for each provider when creating or ed
 ## Chunking and Optimization
 When you upload a document, OCS breaks it into smaller parts called **chunks** and stores them in the index. The default chunking settings work well for most use cases.
 
-For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Index Optimization](../../tech-hub/rag-optimization.md).
+For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Index Optimization](../../tech-hub/local-index-optimization.md).
 
 [file-search]: ../experiment/index.md#file-search
 [migration-guide]: ../../how-to/assistants_migration.md

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -23,6 +23,8 @@ Common examples include:
 
 If you’ve used the OpenAI Assistants’ [file search][file-search] capability in OCS, you’ve already interacted with an index behind the scenes.
 
+To search documents by meaning, OCS uses an **embedding model** — a component that converts text into a mathematical form so the chatbot can find conceptually related content even when the exact words don't match. For example, a user asking "how do I cancel?" can match a document that says "terminating your subscription."
+
 In OCS, there are two types of indexes:
 
 - Remote Index

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -22,7 +22,7 @@ When you want your chatbot to be able to send multimedia files to users.
 Once a collection is linked, your bot will be able to send one or more files from it to users—either as a download link or directly—depending on the specific channel’s support for the file type and file size.
 
 !!! note "Changes take effect on published chatbots immediately"
-    Adding, removing, or replacing files in a media collection is reflected in the published chatbot without requiring a republish. See [Collections and published bots](./index.md#collections-and-published-bots) for more detail.
+    Adding, removing, or replacing files in a media collection is reflected in the published chatbot without requiring a republish. See [Collections and published chatbots](index.md#collections-and-published-chatbots) for more detail.
 
 ## How does it work?
 ### How does the bot know when to attach a file?

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -25,7 +25,7 @@ Once a collection is linked, your chatbot will be able to send one or more files
     Adding, removing, or replacing files in a media collection is reflected in the published chatbot without requiring a republish. See [Collections and published chatbots](index.md#collections-and-published-chatbots) for more detail.
 
 ## How does it work?
-### How does the bot know when to attach a file?
+### How does the chatbot know when to attach a file?
 
 When you create a collection and upload files to it, you'll be prompted to add a summary for each file. These summaries are included in the system prompt when you link a collection to your chatbot. This allows the chatbot to accurately determine when a particular file is relevant to a conversation.
 

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -3,7 +3,7 @@ title: Media collections
 ---
 
 ## When should I use this?
-When you want your bot to be able to send multimedia files to users.
+When you want your chatbot to be able to send multimedia files to users.
 
 ## Currently supported file types
 
@@ -21,15 +21,15 @@ When you want your bot to be able to send multimedia files to users.
 
 Once a collection is linked, your bot will be able to send one or more files from it to users—either as a download link or directly—depending on the specific channel’s support for the file type and file size.
 
-!!! note "Changes take effect on published bots immediately"
-    Adding, removing, or replacing files in a media collection is reflected in the published bot without requiring a republish. See [Collections and published bots](./index.md#collections-and-published-bots) for more detail.
+!!! note "Changes take effect on published chatbots immediately"
+    Adding, removing, or replacing files in a media collection is reflected in the published chatbot without requiring a republish. See [Collections and published bots](./index.md#collections-and-published-bots) for more detail.
 
 ## How does it work?
 ### How does the bot know when to attach a file?
 
 When you create a collection and upload files to it, you'll be prompted to add a summary for each file. These summaries are included in the system prompt when you link a collection to your bot. This allows the bot to accurately determine when a particular file is relevant to a conversation.
 
-Additionally, OCS automatically provides the bot with a tool that enables it to attach files to its responses.
+Additionally, OCS automatically provides the chatbot with a tool that enables it to attach files to its responses.
 
 The location in the prompt where these summaries are included is defined by the [{media} prompt variable](../prompt_variables.md).
 

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -19,7 +19,7 @@ When you want your chatbot to be able to send multimedia files to users.
 **Audio**
 .mp3, .wav
 
-Once a collection is linked, your bot will be able to send one or more files from it to users—either as a download link or directly—depending on the specific channel’s support for the file type and file size.
+Once a collection is linked, your chatbot will be able to send one or more files from it to users—either as a download link or directly—depending on the specific channel’s support for the file type and file size.
 
 !!! note "Changes take effect on published chatbots immediately"
     Adding, removing, or replacing files in a media collection is reflected in the published chatbot without requiring a republish. See [Collections and published chatbots](index.md#collections-and-published-chatbots) for more detail.
@@ -27,7 +27,7 @@ Once a collection is linked, your bot will be able to send one or more files fro
 ## How does it work?
 ### How does the bot know when to attach a file?
 
-When you create a collection and upload files to it, you'll be prompted to add a summary for each file. These summaries are included in the system prompt when you link a collection to your bot. This allows the bot to accurately determine when a particular file is relevant to a conversation.
+When you create a collection and upload files to it, you'll be prompted to add a summary for each file. These summaries are included in the system prompt when you link a collection to your chatbot. This allows the chatbot to accurately determine when a particular file is relevant to a conversation.
 
 Additionally, OCS automatically provides the chatbot with a tool that enables it to attach files to its responses.
 

--- a/docs/how-to/document_sources.md
+++ b/docs/how-to/document_sources.md
@@ -1,0 +1,88 @@
+---
+title: Set Up Document Sources
+---
+
+Document sources let OCS automatically fetch and index content from an external system on a schedule. This keeps your indexed collection up to date without manual uploads.
+
+For a conceptual overview, see [Indexed Collection for RAG](../concepts/collections/indexed.md#document-sources).
+
+## Prerequisites
+
+- An [indexed collection](../concepts/collections/indexed.md) already created in OCS.
+- An [authentication provider](../concepts/team/authentication_providers.md) configured for your document source (see per-source instructions below).
+
+## Add a Document Source
+
+1. Navigate to your indexed collection and open the **Document Sources** tab.
+2. Click **Add document source** and select the source type.
+3. Complete the configuration fields for your chosen source (see below).
+4. Click **Save**. OCS will run an initial sync immediately.
+
+---
+
+## Confluence
+
+Load pages from a Confluence site. You can filter which pages are loaded by space, label, CQL query, or individual page IDs.
+
+### Authentication
+
+Use a [Basic Auth](../concepts/team/authentication_providers.md#basic-auth) authentication provider. Set your Atlassian username as the **username** and your Atlassian API key as the **password**.
+
+### Configuration
+
+| Field     | Description                                                               |
+|-----------|---------------------------------------------------------------------------|
+| Site URL  | The URL of your Confluence site (e.g. `https://yoursite.atlassian.net/wiki`) |
+| Max Pages | The maximum number of pages to load                                       |
+| Space Key | Load all pages from this space                                            |
+| Label     | Load pages that have this label                                           |
+| CQL       | A CQL query to select which pages to load                                 |
+| Page IDs  | Load only these specific pages (comma-separated IDs)                      |
+
+!!! note
+    Only one of **Space Key**, **Label**, **CQL**, and **Page IDs** can be used at a time.
+
+---
+
+## GitHub
+
+Load files from a GitHub repository. You can filter by path prefix or filename patterns.
+
+### Authentication
+
+Use a [Bearer Token](../concepts/team/authentication_providers.md#bearer-token) authentication provider with a GitHub personal access token.
+
+### Configuration
+
+| Field          | Description                                                          |
+|----------------|----------------------------------------------------------------------|
+| Repository URL | GitHub repository URL (e.g. `https://github.com/user/repo`)          |
+| Branch         | Git branch to sync from                                              |
+| File Pattern   | File patterns to include. Prefix with `!` to exclude matching files. |
+| Path Filter    | Optional path prefix to filter files (e.g. `docs/`)                  |
+
+---
+
+## Monitoring Sync Status
+
+OCS tracks the history of every sync run for each document source. Use the sync logs to confirm that syncs are completing successfully and to diagnose problems when they are not.
+
+Each document source displays a status indicator showing the outcome of the most recent sync:
+
+- **Error** — the last sync encountered a problem. The indicator is shown in red. Open the sync log for details.
+- **Success** — the last sync completed without errors.
+- **In progress** — a sync is currently running. The indicator animates to show activity.
+
+## Troubleshooting
+
+**Sync shows Error status**
+
+Open the sync log for the failed run. Common causes:
+
+- Authentication credentials have expired or been revoked — update your authentication provider.
+- The Confluence space key or GitHub repository URL has changed — update the configuration field.
+- The Max Pages limit was reached before all pages were loaded — increase the limit or narrow your filter.
+
+**Pages are not updating after a sync**
+
+Check that the correct Space Key, Label, CQL, or Page IDs are set. Only one filter field can be active at a time — if multiple are filled in, only one will be used.

--- a/docs/how-to/document_sources.md
+++ b/docs/how-to/document_sources.md
@@ -1,6 +1,7 @@
 ---
 title: Set Up Document Sources
 ---
+# Set Up Document Sources
 
 Document sources let OCS automatically fetch and index content from an external system on a schedule. This keeps your indexed collection up to date without manual uploads.
 

--- a/docs/tech-hub/index.md
+++ b/docs/tech-hub/index.md
@@ -19,4 +19,5 @@ These topics contain technical facts and code examples.
 - **[Render a Template and Send an Email Nodes](template_and_email_nodes.md)** — Full Jinja2 variable reference, recipient field syntax, and examples for the Render a Template and Send an Email pipeline nodes.
 - **[Tools Reference](tools.md)** — Full argument reference for all built-in tools and the LLM provider tools supported. For a conceptual overview, see [Tools Concepts](../concepts/tools/index.md).
 - **[Evaluations](evaluations/index.md)** — Reference for advanced features of Evaluations — a testing system for measuring chatbot performance against different metrics.
+- **[RAG Index Optimization](rag-optimization.md)** — Advanced configuration for indexed collections: embedding model selection, chunk size, chunk overlap, and per-document-type tuning guidance.
 - **[OCS API Access](api_access.md)** — Interact with OCS chatbots programmatically using the REST API. Useful for third-party integrations and automated evaluation.

--- a/docs/tech-hub/index.md
+++ b/docs/tech-hub/index.md
@@ -19,5 +19,5 @@ These topics contain technical facts and code examples.
 - **[Render a Template and Send an Email Nodes](template_and_email_nodes.md)** — Full Jinja2 variable reference, recipient field syntax, and examples for the Render a Template and Send an Email pipeline nodes.
 - **[Tools Reference](tools.md)** — Full argument reference for all built-in tools and the LLM provider tools supported. For a conceptual overview, see [Tools Concepts](../concepts/tools/index.md).
 - **[Evaluations](evaluations/index.md)** — Reference for advanced features of Evaluations — a testing system for measuring chatbot performance against different metrics.
-- **[RAG Index Optimization](rag-optimization.md)** — Advanced configuration for indexed collections: embedding model selection, chunk size, chunk overlap, and per-document-type tuning guidance.
+- **[Local Index Optimization](local-index-optimization.md)** — Advanced configuration for indexed collections: embedding model selection, chunk size, chunk overlap, and per-document-type tuning guidance.
 - **[OCS API Access](api_access.md)** — Interact with OCS chatbots programmatically using the REST API. Useful for third-party integrations and automated evaluation.

--- a/docs/tech-hub/local-index-optimization.md
+++ b/docs/tech-hub/local-index-optimization.md
@@ -1,6 +1,7 @@
 ---
 title: Local Index Optimization
 ---
+# Local Index Optimization
 
 This page covers advanced configuration options for indexed collections. For a conceptual overview of how indexed collections work, see [Indexed Collection for RAG](../concepts/collections/indexed.md).
 
@@ -17,8 +18,6 @@ Different embedding models have different strengths:
 - Models trained on domain-specific data (medical, legal, code) can outperform general-purpose models in those domains.
 
 You can view the available embedding models for each provider when creating or editing the [LLM provider in your team](../concepts/team/llm_providers.md) settings. If you are unsure which model to choose, start with the default offered by your LLM provider — it is optimised for general-purpose retrieval.
-
-!!! info "Local indexes are a new feature in OCS. We are actively working to support additional embedding models."
 
 ## Chunking and Optimization (Local Indexes only)
 

--- a/docs/tech-hub/local-index-optimization.md
+++ b/docs/tech-hub/local-index-optimization.md
@@ -1,5 +1,5 @@
 ---
-title: RAG Index Optimization
+title: Local Index Optimization
 ---
 
 This page covers advanced configuration options for indexed collections. For a conceptual overview of how indexed collections work, see [Indexed Collection for RAG](../concepts/collections/indexed.md).

--- a/docs/tech-hub/rag-optimization.md
+++ b/docs/tech-hub/rag-optimization.md
@@ -1,0 +1,38 @@
+---
+title: RAG Index Optimization
+---
+
+This page covers advanced configuration options for indexed collections. For a conceptual overview of how indexed collections work, see [Indexed Collection for RAG](../concepts/collections/indexed.md).
+
+## Choosing an Embedding Model (Local Indexes)
+
+When you create a local index, you select which embedding model converts your documents into vectors. The model you choose affects how well the chatbot retrieves relevant content.
+
+Different embedding models have different strengths:
+
+- Some perform better on short, conversational text (FAQs, chat logs).
+- Others are optimised for long, technical documents (reports, manuals, legal text).
+- Models trained on domain-specific data (medical, legal, code) can outperform general-purpose models in those domains.
+
+You can view the available embedding models for each provider when creating or editing the [LLM provider in your team](../concepts/team/llm_providers.md) settings. If you are unsure which model to choose, start with the default offered by your LLM provider — it is optimised for general-purpose retrieval.
+
+!!! info "Local indexes are a new feature in OCS. We are actively working to support additional embedding models."
+
+## Chunking and Optimization
+
+When you upload a document to an index, OCS breaks it into smaller parts called **chunks**. Each chunk is converted into a vector and stored in the index. The chunking strategy affects how accurately the chatbot retrieves relevant content.
+
+In most cases the default chunking strategy works well. You can customise it per set of uploaded files if needed:
+
+| Setting       | What it controls                                        | When to adjust                                                  |
+|---------------|---------------------------------------------------------|-----------------------------------------------------------------|
+| Chunk size    | How large each chunk is, measured in tokens             | Increase for long, dense documents; decrease for short snippets |
+| Chunk overlap | How much each chunk overlaps with the next              | Increase to preserve context across chunk boundaries            |
+
+### Guidelines
+
+- **Short documents or FAQs**: Use smaller chunks (e.g. 256–512 tokens) with low overlap. Each answer fits in one chunk, so large chunks add noise.
+- **Long technical documents or reports**: Use larger chunks (e.g. 512–1024 tokens) with moderate overlap (10–20%) to preserve context across sections.
+- **Structured data (tables, forms)**: Experiment with overlap settings — tables often lose meaning when split mid-row.
+
+!!! warning "Changing the chunking strategy after upload requires re-indexing your files."

--- a/docs/tech-hub/rag-optimization.md
+++ b/docs/tech-hub/rag-optimization.md
@@ -6,7 +6,9 @@ This page covers advanced configuration options for indexed collections. For a c
 
 ## Choosing an Embedding Model (Local Indexes)
 
-When you create a local index, you select which embedding model converts your documents into vectors. The model you choose affects how well the chatbot retrieves relevant content.
+An embedding model converts your documents into a mathematical form that enables search by *meaning* rather than exact keywords. When a user asks a question, the chatbot finds content that is conceptually related — even if it uses different words. The quality and focus of the embedding model directly affects how relevant the retrieved content is.
+
+When you create a local index, you select which embedding model to use. The model you choose affects how well the chatbot retrieves relevant content.
 
 Different embedding models have different strengths:
 
@@ -18,9 +20,12 @@ You can view the available embedding models for each provider when creating or e
 
 !!! info "Local indexes are a new feature in OCS. We are actively working to support additional embedding models."
 
-## Chunking and Optimization
+## Chunking and Optimization (Local Indexes only)
 
-When you upload a document to an index, OCS breaks it into smaller parts called **chunks**. Each chunk is converted into a vector and stored in the index. The chunking strategy affects how accurately the chatbot retrieves relevant content.
+!!! info
+    Chunking is configured in OCS for local indexes only. For remote indexes, the provider (e.g. OpenAI) handles chunking internally and it cannot be configured.
+
+When you upload a document to a local index, OCS breaks it into smaller parts called **chunks**. Each chunk is converted into a vector and stored in the index. The chunking strategy affects how accurately the chatbot retrieves relevant content.
 
 In most cases the default chunking strategy works well. You can customise it per set of uploaded files if needed:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
       - Annotating: concepts/annotations/annotating.md
   - Tech Hub:
     - tech-hub/index.md
+    - RAG Index Optimization: tech-hub/rag-optimization.md
     - Tools Reference: tech-hub/tools.md
     - Python Node: tech-hub/python_node.md
     - Render a Template and Send an Email Nodes: tech-hub/template_and_email_nodes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,7 +173,7 @@ nav:
       - Annotating: concepts/annotations/annotating.md
   - Tech Hub:
     - tech-hub/index.md
-    - RAG Index Optimization: tech-hub/rag-optimization.md
+    - Local Index Optimization: tech-hub/local-index-optimization.md
     - Tools Reference: tech-hub/tools.md
     - Python Node: tech-hub/python_node.md
     - Render a Template and Send an Email Nodes: tech-hub/template_and_email_nodes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - Adjust LLM Node Model Parameters: how-to/adjust_llm_node_model_parameters.md
     - how-to/workflow_cookbook.md
     - how-to/add_a_knowledge_base.md
+    - Set Up Document Sources: how-to/document_sources.md
     - how-to/deploy_to_different_channels.md
     - Surveys (Deprecated): how-to/setting_up_a_survey.md
     - Schedule Reminders: how-to/reminders.md


### PR DESCRIPTION
### Background

The concept page for Collections and Indexed Collections (for RAG) are solid. However, the implementation details are taking over so its a confusing concept page for a new user

Resolves https://github.com/dimagi/open-chat-studio-docs/issues/409 

#### Summary of changes

- Added 2 new pages from content split from Indexed Collections
- New Tech Hub page for the "Chunking and Optimization" content
- New how-to/document_sources.md for content about setting up document sources
- Readability of Indexed collections by adding a real-world use case section at the top 
- a new section to help users choose between remote and local index

### Notes for Reviewer

- Should we still reference OpenAI assistants in these pages?
- removed local indexes are "a new feature in OCS" as this was implemented a year ago
