### PR TITLE
Stripped extra newline in api .txt files for lint checking

### DIFF
--- a/src/ocs_docs/openapi_to_docs.py
+++ b/src/ocs_docs/openapi_to_docs.py
@@ -288,7 +288,7 @@ class OpenAPIToMarkdownConverter:
         # API header info
         lines.append(f"API: {self.base_info['title']} {self.base_info['version']}")
         if self.base_info.get("description"):
-            lines.append(f"Description: {self.base_info['description']}")
+            lines.append(f"Description: {self.base_info['description'].strip()}")
         lines.append("")
 
         # Tag info
@@ -296,7 +296,7 @@ class OpenAPIToMarkdownConverter:
         if tag != "Untagged":
             lines.append(f"TAG: {tag}")
             if tag_info and tag_info.get("description"):
-                lines.append(f"Description: {tag_info['description']}")
+                lines.append(f"Description: {tag_info['description'].strip()}")
             lines.append("")
 
         lines.append("ENDPOINTS:")
@@ -386,7 +386,7 @@ class OpenAPIToMarkdownConverter:
         # Description (only if different from summary)
         description = operation.get("description")
         if description and description != operation.get("summary"):
-            lines.append(f"  Description: {description}")
+            lines.append(f"  Description: {description.strip()}")
 
         # Parameters
         parameters = operation.get("parameters", [])


### PR DESCRIPTION
### Background

When enabling more Markdown lint checks, I am seeing that the **api .txt docs** are showing trailing space issues that it wants to fix

### Done
fixed when the .txt files for API docs for LLM consumption are created - `openapi-to-docs.py`