### PR TITLE
Enable more markdown lint rules & fixes

### DIFF
--- a/.github/templates/changelog-compaction-instructions.md
+++ b/.github/templates/changelog-compaction-instructions.md
@@ -15,7 +15,7 @@ For each calendar month earlier than the cutoff, replace all of its per-day sect
 month and year only. Use the **abbreviated month** form to match the file's existing
 day headings (`## Jun 22, 2026` → `## Jun 2026`, `## Apr 8, 2026` → `## Apr 2026`):
 
-```
+```markdown
 ## May 2026
 ```
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -48,7 +48,7 @@ MD030: false
 #MD031: false
 MD032: false
 MD034: false
-MD036: false
+
 MD041: false
 
 # TODO: enable this for alt text on images for accessibility, but disable for now because we have some images without alt text

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -42,17 +42,15 @@ MD024:
 MD025: false
 
 MD026: false
-MD029: false
-# TODO: Ordered list style: allow 1. 1. 1. (auto-numbering) as well as 1. 2. 3.
+MD029:
+  style: one_or_ordered
 MD030: false
-#MD031: false
+
 MD032: false
 MD034: false
 
 MD041: false
 
-# TODO: enable this for alt text on images for accessibility, but disable for now because we have some images without alt text
-MD045: false
 MD046: false
 MD050: false
 MD053: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](docs/assets/logo.png)](https://github.com/dimagi/open-chat-studio)
+[![OCS Logo](docs/assets/logo.png)](https://github.com/dimagi/open-chat-studio)
 
 This repository contains the user documentation for [Open Chat Studio](https://github.com/dimagi/open-chat-studio).
 

--- a/docs/chat_widget/changelog.md
+++ b/docs/chat_widget/changelog.md
@@ -190,11 +190,11 @@ Check your current HTML implementation and compare it with the [latest propertie
 
 #### Attribute changes
 
-**Added**
+##### Added
 
 * `allow-full-screen`: Allow the user to make the chat window full screen.
 
-**Removed**
+##### Removed
 
 * `expanded`
 

--- a/docs/chat_widget/reference.md
+++ b/docs/chat_widget/reference.md
@@ -14,17 +14,17 @@ The widget button can be customized using the following properties:
 </open-chat-studio-widget>
 ```
 
-**Button Text**
+### Button Text
 
 - When button-text is provided, the button displays both icon and text
 - When button-text is empty or not provided, only an icon is shown
 
-**Button Shape**
+### Button Shape
 
 - **round** - Circular button
 - **square** - Rectangular button with rounded corners
 
-**Icon URL**
+### Icon URL
 
 If no icon-url is provided, the default Open Chat Studio avatar is used.
 

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -88,11 +88,11 @@ The following document source types are currently supported:
 
 Load pages from a Confluence site. Pages can be filtered using the space key, label, CQL, or individual page IDs.
 
-**Authentication**
+#### Authentication
 
 Use a [Basic Auth](../team/authentication_providers.md#basic-auth) authentication provider with your Atlassian username and use your API Key as the password.
 
-**Configuration**
+#### Configuration
 
 | Field     | Description                                                               |
 |-----------|---------------------------------------------------------------------------|
@@ -111,11 +111,11 @@ Use a [Basic Auth](../team/authentication_providers.md#basic-auth) authenticatio
 
 Load pages from a GitHub repository. Files can be filtered by path and by matching patterns against the filenames.
 
-**Authentication**
+#### Authentication
 
 Use a [Bearer Token](../team/authentication_providers.md#bearer-token) authentication provider.
 
-**Configuration**
+#### Configuration
 
 | Field          | Description                                                          |
 |----------------|----------------------------------------------------------------------|

--- a/docs/concepts/evaluations/evaluators.md
+++ b/docs/concepts/evaluations/evaluators.md
@@ -29,7 +29,7 @@ Consider the conversation context: {context.topic}
 
 The available variables depend on the evaluator's evaluation mode.
 
-**Message-level variables**
+#### Message-level variables
 
 | Variable | Description |
 |---|---|
@@ -39,7 +39,7 @@ The available variables depend on the evaluator's evaluation mode.
 | `{context.[parameter]}` | Any context variable, e.g. `{context.topic}` |
 | `{full_history}` | Complete conversation history as formatted text |
 
-**Session-level variables**
+#### Session-level variables
 
 In session-level mode, `{input.content}` and `{output.content}` are empty. Use the following variables instead:
 

--- a/docs/concepts/tags.md
+++ b/docs/concepts/tags.md
@@ -4,7 +4,7 @@ Tags are labels applied to chats and messages to categorize and organize interac
 
 Tags can be created using the “Manage Tags” section.
 
-![](../assets/images/tags_manage.png)
+![Manage Tags section showing options to create and edit tags](../assets/images/tags_manage.png)
 
 ## Types Of Tags
 
@@ -19,4 +19,4 @@ These tags are manually added to sessions.
 * Message tags  
 These tags are manually added to specific messages within a user session.
 
-![](../assets/images/tags_screenshot.png)
+![Tags applied to sessions and messages in Open Chat Studio](../assets/images/tags_screenshot.png)

--- a/docs/how-to/evaluations/create-a-dataset.md
+++ b/docs/how-to/evaluations/create-a-dataset.md
@@ -61,7 +61,7 @@ Based on the evaluation level you have chosen, the system will clone either the 
 Use this method to populate a **session-level** dataset from sessions that have already been curated in an [annotation queue](../../concepts/annotations/queues.md). This is useful when your team has reviewed a set of conversations and you want to run automated scoring against the same set.
 
 1. Select a team annotation queue that contains session items (archived queues are excluded).
-3. Click **Import**.
+2. Click **Import**.
 
 Each session item in the queue becomes one row in the dataset, using the same field mapping as [session-level cloning](../../tech-hub/evaluations/dataset-structure.md#session-level-datasets).
 

--- a/docs/how-to/send_email_node.md
+++ b/docs/how-to/send_email_node.md
@@ -49,14 +49,14 @@ The variables available for the Subject, Recipient, and Body fields are [listed 
 
 ## Example use cases
 
-**Notify your team of an emergency**
+### Notify your team of an emergency
 
 Use a [Router node](../concepts/pipelines/router_nodes.md) to detect whether the user needs urgent assistance. In the router's emergency branch, add the Send an Email node with the recipient set to your team address and the body describing the situation. This lets you escalate extraordinary circumstances — such as a user in crisis — without waiting for the session to end.
 
-**Route a completed intake form to the right team member**
+### Route a completed intake form to the right team member
 
 After a bot collects structured information from a user (such as a support request or referral), use an LLM node to extract the key details, then add the Send an Email node to forward them to the appropriate contact. Set the recipient using a participant data field (e.g. `{{ participant_data.assigned_caseworker_email }}`) and use the LLM output as the body.
 
-**Alert your team when a threshold is reached**
+### Alert your team when a threshold is reached
 
 After an [Increment counter](../tech-hub/tools.md#increment-counter) tool updates a counter in participant data, use a router to check the value. When the threshold is met, route to the Send an Email node to trigger an alert.

--- a/docs/how-to/whatsapp_meta_cloud_api.md
+++ b/docs/how-to/whatsapp_meta_cloud_api.md
@@ -69,8 +69,8 @@ Copy and securely store the generated token — this is your **System User Acces
 4. Verify ownership of the number using the one-time code sent by Meta.
 5. Wait for your **display name** to be verified by Meta before proceeding.
 
-!!! info "Display name verification"
-    Display name verification typically takes 2–3 hours. You cannot complete the registration step until this is approved.
+    !!! info "Display name verification"
+        Display name verification typically takes 2–3 hours. You cannot complete the registration step until this is approved.
 
 6. While waiting for display name verification, go to your [system user page](https://business.facebook.com/settings/system-users), click **Add Assets**, select **WhatsApp Accounts**, choose the newly created WhatsApp Business Account, and enable the **Phone numbers view and manage** permission. This is required so the system user's access token can register the phone number in the next step.
 


### PR DESCRIPTION
### Background

Enabled more markdown lint checks to slowly clean up older issues
Asked Claude which checks were the most useful and did these first

### Changes made

- Enabled MD036 check & fixes for -> bold pseudo-headings to proper headings
- Enabled MDO45 for alt text - fixes made
- enabled MD029 for ordered lists - fixes made
- enabled MD031 for blanks around fences

### Reviewer notes

- there are fixes to changelog md files for web chatbot that are just formatting so dont need to be on separate branch