### PR TITLE
Clarify indexed and media collections - use and details

### DIFF
--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -21,7 +21,7 @@ Collection content is a **live shared resource**. When you update the files in a
 This means:
 
 - Adding or removing files from a [media collection](./media.md) takes effect for users immediately.
-- Document-source syncs to a [RAG index collection](./indexed.md) (for example, nightly Confluence or GitHub syncs) are applied to the published chatbot as each sync completes.
+- Document-source syncs to a [index collection](./indexed.md) (for example, nightly Confluence or GitHub syncs) are applied to the published chatbot as each sync completes.
 
 The *structure* of a published version — which collections are linked to which pipeline nodes — is still frozen at publish time. To change which collections a chatbot uses, you must publish a new version.
 

--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -1,9 +1,12 @@
 # Collections
 
-A collection in OCS refers to a collection of files. There are two types of collections:
+A collection is a group of files you attach to a chatbot. There are two types:
 
-- [Media collection](./media.md)
-- [Indexed Collection (for RAG applications)](./indexed.md)
+[Media collection](./media.md)
+: Send files — such as images, PDFs, video, or audio — to participants during a conversation.
+
+[Indexed collection](./indexed.md)
+: Let your chatbot search your documents and ground its answers in that content (RAG).
 
 ## Adding a collection to a chatbot
 
@@ -17,8 +20,8 @@ Collection content is a **live shared resource**. When you update the files in a
 
 This means:
 
-- Adding or removing files from a media collection takes effect for users immediately.
-- Document-source syncs to a RAG index collection (for example, nightly Confluence or GitHub syncs) are applied to the published chatbot as each sync completes.
+- Adding or removing files from a [media collection](./media.md) takes effect for users immediately.
+- Document-source syncs to a [RAG index collection](./indexed.md) (for example, nightly Confluence or GitHub syncs) are applied to the published chatbot as each sync completes.
 
 The *structure* of a published version — which collections are linked to which pipeline nodes — is still frozen at publish time. To change which collections a chatbot uses, you must publish a new version.
 

--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -21,7 +21,7 @@ Collection content is a **live shared resource**. When you update the files in a
 This means:
 
 - Adding or removing files from a [media collection](./media.md) takes effect for users immediately.
-- Document-source syncs to a [index collection](./indexed.md) (for example, nightly Confluence or GitHub syncs) are applied to the published chatbot as each sync completes.
+- Document-source syncs to an [indexed collection](./indexed.md) (for example, nightly Confluence or GitHub syncs) are applied to the published chatbot as each sync completes.
 
 The *structure* of a published version — which collections are linked to which pipeline nodes — is still frozen at publish time. To change which collections a chatbot uses, you must publish a new version.
 

--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -24,26 +24,4 @@ The *structure* of a published version — which collections are linked to which
 
 For more detail on how versioning interacts with collections, see [Versioning](../versioning.md#what-is-frozen-and-what-is-live).
 
-## How are attachments sent?
-Whenever your chatbot references a particular file or document, it will be sent to the user as an attachment. Depending on the channel, attachments are delivered in different ways.
-
-### Web channels
-Attachments are directly downloadable by clicking on them.
-
-### Multimedia-unsupported channels
-By default, attachments are sent as download links appended to the chatbot's message. The user will see the file name and a corresponding download link at the end of the message. These channels do not yet support sending multimedia files:
-
-* Telegram
-* WhatsApp (Turn.io provider)
-* SureAdhere
-* Facebook Messenger
-* Slack
-
-### Multimedia-supported channels
-Channels that support sending multimedia files will receive each attachment as a separate message, following the chatbot's initial response. If a file type is not supported by the channel, or the file size exceeds the allowed limit, a download link will be appended to the chatbot's message instead. These channels support sending multimedia files:
-
-* API - See the [API documentation](https://openchatstudio.com/api/v1/docs/#tag/Channels/operation/new_api_message) for more information
-* WhatsApp (Twilio Provider) - Consult the [Twilio docs][twilio_docs] for supported file types.
-
 [llm_node]: ../pipelines/nodes.md
-[twilio_docs]: https://www.twilio.com/docs/whatsapp/guidance-whatsapp-media-messages

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -16,10 +16,7 @@ Common examples include:
 
 ## How it works
 
-!!! note "Definition"
-    **Retrieval-Augmented Generation** (RAG) is a technique where a language model retrieves relevant information from a set of documents to ground its answers in real data. Instead of relying solely on its built-in knowledge, the model uses indexes—specialized databases that store document content as vectors (numerical representations of meaning). This makes it easy for the model to find and use the most relevant parts of your uploaded files when answering questions.
-
-To search documents by meaning, OCS uses an **embedding model** to convert text into a mathematical form that captures meaning, not just keywords. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md) for a full explanation.
+To search documents by meaning, OCS uses an **embedding model** — this technique is called **Retrieval-Augmented Generation (RAG)**. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md) for a full explanation.
 
 ## Which should I use?
 
@@ -33,6 +30,7 @@ In OCS, there are two types of indexes:
 | **Managed by** | Your LLM provider (e.g. OpenAI) | OCS |
 | **Setup** | Simpler — the provider handles everything | More steps — you choose the embedding model |
 | **Embedding model** | Selected by the provider | You choose |
+| **Chunking** | Handled by provider, not configurable | Configurable per file set |
 | **Collections per LLM node** | Max 2 (OpenAI limit) | Unlimited |
 | **Best for** | Getting started quickly | More control, or more than 2 collections |
 
@@ -74,7 +72,7 @@ Local indexes are hosted and managed by OCS. When you create a local index, you 
 ### Supported embedding models
 You can see the supported embedding models for each provider when creating or editing the provider in your team settings.
 
-## Chunking and Optimization (Local Indexes only)
+### Chunking and Optimization
 When you upload a document to a local index, OCS breaks it into smaller parts called **chunks** and stores them in the index. The default chunking settings work well for most use cases.
 
 For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md).
@@ -84,7 +82,7 @@ For advanced configuration — including chunk size, chunk overlap, and embeddin
 
 ## Document Sources
 
-Instead of uploading files manually, you can connect OCS to an external source — such as a Confluence space or GitHub repository — and have it fetch and index content automatically on a schedule. This keeps your collection current without manual uploads.
+Instead of uploading files manually, you can connect OCS to an external source — such as a Confluence space or GitHub repository — and have it fetch and index content automatically on a schedule. This keeps your indexed collection (both remote and local) current without manual uploads.
 
 !!! note "Document-source updates reach published chatbots automatically"
     When a document-source sync runs and updates the collection's content, those changes are applied to your published chatbot without requiring a republish. See [Collections and published chatbots](./index.md#collections-and-published-chatbots) for more detail.

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -57,7 +57,7 @@ Supported files are determined by the selected provider:
 
 ## Local Index
 
-Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
+Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model) for guidance.
 
 ### Supported providers
 - OpenAI
@@ -76,9 +76,6 @@ You can see the supported embedding models for each provider when creating or ed
 When you upload a document to a local index, OCS breaks it into smaller parts called **chunks** and stores them in the index. The default chunking settings work well for most use cases.
 
 For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md).
-
-[file-search]: ../experiment/index.md#file-search
-[migration-guide]: ../../how-to/assistants_migration.md
 
 ## Document Sources
 

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -1,6 +1,7 @@
 ---
 title: Indexed Collection (for RAG applications)
 ---
+# Indexed Collections
 
 An indexed collection lets your chatbot search through your documents to find relevant information before responding. Instead of relying on the AI's built-in knowledge, the chatbot retrieves answers from files you upload — such as PDFs, reports, or wiki pages.
 
@@ -16,7 +17,7 @@ Common examples include:
 
 ## How it works
 
-To search documents by meaning, OCS uses an **embedding model** — this technique is called **Retrieval-Augmented Generation (RAG)**. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md) for a full explanation.
+To search documents by meaning, OCS uses an **embedding model** — this technique is called **Retrieval-Augmented Generation (RAG)**. See [Local Index Optimization](../../tech-hub/local-index-optimization.md) for a full explanation.
 
 ## Which should I use?
 
@@ -34,7 +35,7 @@ In OCS, there are two types of indexes:
 | **Collections per LLM node** | Max 2 (OpenAI limit) | Unlimited |
 | **Best for** | Getting started quickly | More control, or more than 2 collections |
 
-If you are new to indexed collections, start with a **Remote Index**. Switch to a Local Index if you need more than 2 collections or want to choose a specific embedding model for your content type.
+If you are new to indexed collections, start with a **Remote Index**. Switch to a Local Index if you need more than 2 collections or want to [choose a specific embedding model](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model) for your content type.
 
 ## Remote Index
 Remote indexes are hosted and managed by your LLM provider. Files are uploaded to the provider, which handles all indexing. The embedding model is chosen by the provider.
@@ -57,7 +58,7 @@ Supported files are determined by the selected provider:
 
 ## Local Index
 
-Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model) for guidance.
+Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [Local Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model) for guidance.
 
 ### Supported providers
 - OpenAI

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -21,10 +21,6 @@ Common examples include:
 
 To search documents by meaning, OCS uses an **embedding model** to convert text into a mathematical form that captures meaning, not just keywords. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md) for a full explanation.
 
-!!! warning "Indexed collections will replace OpenAI Assistants' file search functionality in the future"
-
-    If you've used the OpenAI Assistants' [file search][file-search] capability in OCS, you've already interacted with an index behind the scenes. Consult the [migration guide][migration-guide] if you have assistants you want to replace with indexed collections.
-
 ## Which should I use?
 
 In OCS, there are two types of indexes:
@@ -62,7 +58,6 @@ Supported files are determined by the selected provider:
 - OpenAI - See the [OpenAI docs](https://platform.openai.com/docs/assistants/tools/file-search/supported-files#supported-files)
 
 ## Local Index
-!!! info "Local indexes are actively developed. We are working to support additional file types and embedding models so you can better customize your index."
 
 Local indexes are hosted and managed by OCS. When you create a local index, you choose which embedding model to use. Different models suit different types of content, so choosing the right one can improve retrieval accuracy. See [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md#choosing-an-embedding-model-local-indexes) for guidance.
 

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -76,7 +76,7 @@ You can see the supported embedding models for each provider when creating or ed
 ### Chunking and Optimization
 When you upload a document to a local index, OCS breaks it into smaller parts called **chunks** and stores them in the index. The default chunking settings work well for most use cases.
 
-For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [RAG Local Index Optimization](../../tech-hub/local-index-optimization.md).
+For advanced configuration — including chunk size, chunk overlap, and embedding model selection — see [Local Index Optimization](../../tech-hub/local-index-optimization.md).
 
 ## Document Sources
 

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -36,14 +36,41 @@ The location in the prompt where these summaries are included is defined by the 
 Here’s an example of how file details appear in the system prompt:
 
 ```text
-You are a friendly assistant. Here's some files that you can attach to your responses when you think the user will benefit from it:
+You are a friendly assistant. Here’s some files that you can attach to your responses when you think the user will benefit from it:
 {media}
 ```
 
 becomes
 
 ```text
-You are a friendly assistant. Here's some files that you can attach to your responses when you think the user will benefit from it:
+You are a friendly assistant. Here’s some files that you can attach to your responses when you think the user will benefit from it:
 * File (id=22, content_type=image/png): This is an image of a border collie
 * File (id=23, content_type=application/pdf): This file contains information about the behaviours of border collies
 ```
+
+## How are attachments sent?
+
+Whenever your chatbot references a file, it is sent to the user as an attachment. Depending on the channel, attachments are delivered in different ways.
+
+### Web channels
+
+Attachments are directly downloadable by clicking on them.
+
+### Multimedia-unsupported channels
+
+By default, attachments are sent as download links appended to the chatbot’s message. The user will see the file name and a corresponding download link at the end of the message. These channels do not yet support sending multimedia files:
+
+* Telegram
+* WhatsApp (Turn.io provider)
+* SureAdhere
+* Facebook Messenger
+* Slack
+
+### Multimedia-supported channels
+
+Channels that support sending multimedia files will receive each attachment as a separate message, following the chatbot’s initial response. If a file type is not supported by the channel, or the file size exceeds the allowed limit, a download link will be appended to the chatbot’s message instead. These channels support sending multimedia files:
+
+* API — see the [API documentation](https://openchatstudio.com/api/v1/docs/#tag/Channels/operation/new_api_message) for more information
+* WhatsApp (Twilio Provider) — consult the [Twilio docs][twilio_docs] for supported file types.
+
+[twilio_docs]: https://www.twilio.com/docs/whatsapp/guidance-whatsapp-media-messages

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -36,7 +36,7 @@ The location in the prompt where these summaries are included is defined by the 
 Here’s an example of how file details appear in the system prompt:
 
 ```text
-You are a friendly assistant. Here’s some files that you can attach to your responses when you think the user will benefit from it:
+You are a friendly assistant. Here's some files that you can attach to your responses when you think the user will benefit from it:
 {media}
 ```
 

--- a/docs/tech-hub/local-index-optimization.md
+++ b/docs/tech-hub/local-index-optimization.md
@@ -5,7 +5,7 @@ title: Local Index Optimization
 
 This page covers advanced configuration options for indexed collections. For a conceptual overview of how indexed collections work, see [Indexed Collection for RAG](../concepts/collections/indexed.md).
 
-## Choosing an Embedding Model (Local Indexes)
+## Choosing an Embedding Model
 
 An embedding model converts your documents into a mathematical form that enables search by *meaning* rather than exact keywords. When a user asks a question, the chatbot finds content that is conceptually related — even if it uses different words. The quality and focus of the embedding model directly affects how relevant the retrieved content is.
 
@@ -19,7 +19,7 @@ Different embedding models have different strengths:
 
 You can view the available embedding models for each provider when creating or editing the [LLM provider in your team](../concepts/team/llm_providers.md) settings. If you are unsure which model to choose, start with the default offered by your LLM provider — it is optimised for general-purpose retrieval.
 
-## Chunking and Optimization (Local Indexes only)
+## Chunking and Optimization
 
 !!! info
     Chunking is configured in OCS for local indexes only. For remote indexes, the provider (e.g. OpenAI) handles chunking internally and it cannot be configured.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,7 +165,7 @@ nav:
     - Collections:
       - concepts/collections/index.md
       - concepts/collections/media.md
-      - Indexed Collection for RAG: concepts/collections/indexed.md
+      - Indexed Collection: concepts/collections/indexed.md
     - Evaluations:
       - concepts/evaluations/index.md
       - concepts/evaluations/dataset.md


### PR DESCRIPTION
### Background

Finishes work done for https://github.com/dimagi/open-chat-studio-docs/issues/409

### Restructures and clarifies the indexed and media collection docs:

1. collections/index.md — add description for each collection type's use case at a glance, so users can navigate to the right page without clicking through both
2. collections/indexed.md — moves the Chunking section under ## Local Index (where it belongs),
3. collections/media.md — moves the "How are attachments sent?" channel breakdown here from the collections overview, where it was misplaced (attachment delivery is a media collection concern, not a general collections concern)
4. tech-hub/local-index-optimization.md — removes out-of-date warnings

### Reviewer Notes

This warning about only 2 collections for Remote Indexes needs to be checked : https://docs.openchatstudio.com/concepts/collections/indexed/#remote-index

- I see from Deepwiki that its in the code
- I cant find the documentation on OpenAI about the limit of 2 vector stores