### PR TITLE
docs: document per-channel file support

### DIFF
--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -12,7 +12,27 @@ The currently supported channels are:
 - SureAdhere
 - Email
 
+## File support
+
+Channels differ in whether users can send files to the bot and whether the bot can send files back. When the bot produces a file that a channel cannot deliver — because the channel doesn't support file sending, or the file's type or size isn't allowed — OCS appends a download link to the bot's message instead, so the user can still get the file.
+
+| Channel | Users can send files | Bot can send files | Types and limits |
+|---|---|---|---|
+| Web / Chat widget | Yes | As download links | Uploads of up to 50 MB per file (50 MB total per message). Text files are always accepted, along with common document, image, audio and video formats. See the [widget file attachments reference][widget-files] for the full list. |
+| API | Yes | As attachment metadata | Same upload limits as the web channel. Files the bot produces are returned on the message as attachments with download links. |
+| Telegram | No | Yes | Outgoing: images up to 10 MB; audio, video and documents up to 50 MB. Photos and documents sent by users are not accepted. |
+| WhatsApp | Yes | Yes | Incoming: images and documents (a caption becomes the message text). Outgoing: images up to 5 MB, audio and video up to 16 MB, documents up to 100 MB. Applies to all providers (Twilio, Turn.io, Meta Cloud API). |
+| Facebook Messenger | No | As download links | Text and voice messages only. |
+| Slack | No | Yes | Outgoing: images, audio, video and documents up to 50 MB. |
+| Email | Yes | Yes | Attachments up to 20 MB in both directions. Executable file types are blocked. See [email file attachments][email-files] for details. |
+| SureAdhere | No | As download links | Text messages only. |
+
+!!! info "Voice notes"
+    Voice notes are handled separately from file attachments. On channels with voice support (Telegram and WhatsApp), a voice note from the user is transcribed and processed as a regular message rather than being treated as a file.
+
 ## See also
 - [Deploying your bot to different channels](../how-to/deploy_to_different_channels.md)
 
 [1]: ./team/messaging_providers.md
+[widget-files]: ../chat_widget/reference.md#file-attachments
+[email-files]: ../how-to/deploy_to_different_channels.md#file-attachments

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -28,7 +28,7 @@ Channels differ in whether users can send files to the bot and whether the bot c
 | SureAdhere | No | As download links | Text messages only. |
 
 !!! info "Voice notes"
-    Voice notes are handled separately from file attachments. On channels with voice support (Telegram and WhatsApp), a voice note from the user is transcribed and processed as a regular message rather than being treated as a file.
+    Voice notes are handled separately from file attachments. On channels with voice support (Telegram, WhatsApp and Facebook Messenger), a voice note from the user is transcribed and processed as a regular message rather than being treated as a file.
 
 ## See also
 - [Deploying your bot to different channels](../how-to/deploy_to_different_channels.md)

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -22,10 +22,10 @@ Channels differ in whether users can send files to the bot and whether the bot c
 | API | Yes | As attachment metadata | Same upload limits as the web channel. Files the bot produces are returned on the message as attachments with download links. |
 | Telegram | No | Yes | Outgoing: images up to 10 MB; audio, video and documents up to 50 MB. Photos and documents sent by users are not accepted. |
 | WhatsApp | Yes | Yes | Incoming: images and documents (a caption becomes the message text). Outgoing: images up to 5 MB, audio and video up to 16 MB, documents up to 100 MB. Applies to all providers (Twilio, Turn.io, Meta Cloud API). |
-| Facebook Messenger | No | As download links | Text and voice messages only. |
+| Facebook Messenger | No | As download links | No files in either direction; text and voice messages only. |
 | Slack | No | Yes | Outgoing: images, audio, video and documents up to 50 MB. |
 | Email | Yes | Yes | Attachments up to 20 MB in both directions. Executable file types are blocked. See [email file attachments][email-files] for details. |
-| SureAdhere | No | As download links | Text messages only. |
+| SureAdhere | No | As download links | No files in either direction; text messages only. |
 
 !!! info "Voice notes"
     Voice notes are handled separately from file attachments. On channels with voice support (Telegram, WhatsApp and Facebook Messenger), a voice note from the user is transcribed and processed as a regular message rather than being treated as a file.

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -143,7 +143,7 @@ When the bot starts a new email thread (for example, via the [Trigger Bot Messag
 
 ### File attachments
 
-The email channel supports bidirectional file attachments.
+The email channel supports bidirectional file attachments. For a comparison of file support across all channels, see [channel file support](../concepts/channels.md#file-support).
 
 #### Inbound attachments (user to bot)
 


### PR DESCRIPTION
## Summary

Adds a **File support** section to the channels concept page comparing, for each channel, whether users can send files to the bot and whether the bot can send files back, along with the applicable file type and size limits.

Rather than a standalone page, the matrix lives on the existing `concepts/channels.md` page and links out to the detailed per-channel docs that already exist (widget file attachments reference, email file attachments how-to). Also adds a back-link from the email section of the deploy how-to.

## Details

- Covers Web/widget, API, Telegram, WhatsApp, Facebook Messenger, Slack, Email, and SureAdhere.
- Notes the download-link fallback OCS uses when a channel can't natively deliver a bot-produced file.
- Adds an info callout clarifying that voice notes are transcribed and handled separately from file attachments.
- `zensical build --clean --strict` passes (no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)