### PR TITLE
Clarify how the LLM node uses Indexed Collections - gap in docs

### DIFF
--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -9,7 +9,7 @@ Give your chatbot access to your files — grouped into a **collection** — whe
 
 1. Navigate to the **Collections** section in the sidebar, click "Add new", and choose a collection type: [Media Collection](./media.md) or [Indexed Collection (RAG)](./indexed.md).
 2. Once the collection is created, you will be able to upload files to it.
-3. For indexed collections, you'll also need to choose between a Remote or Local index before uploading — see [Which should I use?](./indexed.md#which-should-i-use).
+3. For indexed collections, you'll also need to choose between a Remote and a Local index before uploading — see [Which should I use?](./indexed.md#which-should-i-use).
 4. After your collection has been created, you can link it to any [LLM node][llm_node]. To actually access the collection's content, add the matching [prompt variable](../prompt_variables.md) to the node's prompt — `{media}` for media collections, or `{collection_index_summaries}` for indexed collections.
 
 ## Collections and published chatbots

--- a/docs/concepts/collections/index.md
+++ b/docs/concepts/collections/index.md
@@ -1,15 +1,16 @@
 # Collections
 
-A collection is a group of files you can attach to a chatbot to give it access to content. There are two types of collections:
+Give your chatbot access to your files — grouped into a **collection** — whether that's sending them to users during a conversation, or letting the chatbot search them to answer questions. There are two types of collections, depending on what you want to do:
 
-- **[Media collection](./media.md)** - Send files — such as images, PDFs, video, or audio — to participants during a conversation.
-- **[Indexed collection](./indexed.md)** - Let your chatbot search your documents and ground its answers in that content (RAG).
+- **Want to send files to users in a conversation?** Use a **[Media collection](./media.md)** — share images, PDFs, video, or audio directly in the chat.
+- **Want your chatbot to answer questions using your documents?** Use an **[Indexed collection](./indexed.md)** — it searches your files and grounds its answers in that content (RAG).
 
 ## Adding a collection to a chatbot
 
-Navigate to the **Collections** section in the sidebar and click "Add new". Once the collection is created, you will be able to upload files to it.
-
-After your collection has been created and populated with files, you can link it to any [LLM node][llm_node].
+1. Navigate to the **Collections** section in the sidebar, click "Add new", and choose a collection type: [Media Collection](./media.md) or [Indexed Collection (RAG)](./indexed.md).
+2. Once the collection is created, you will be able to upload files to it.
+3. For indexed collections, you'll also need to choose between a Remote or Local index before uploading — see [Which should I use?](./indexed.md#which-should-i-use).
+4. After your collection has been created, you can link it to any [LLM node][llm_node]. To actually access the collection's content, add the matching [prompt variable](../prompt_variables.md) to the node's prompt — `{media}` for media collections, or `{collection_index_summaries}` for indexed collections.
 
 ## Collections and published chatbots
 
@@ -28,4 +29,4 @@ The collection *structure* of a published chatbot version — which collections 
 
 For more detail on versioning in general, see [Versioning](../versioning.md).
 
-[llm_node]: ../pipelines/nodes.md
+[llm_node]: ../pipelines/nodes.md#llm-node

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -19,6 +19,10 @@ Common examples include:
 
 To search documents by meaning, OCS uses an **embedding model** — this technique is called **Retrieval-Augmented Generation (RAG)**. See [Local Index Optimization](../../tech-hub/local-index-optimization.md) for a full explanation.
 
+## Using it in a chatbot
+
+Once your collection is created and populated with files, [link it to an LLM node](./index.md#adding-a-collection-to-a-chatbot). Linking the collection isn't enough on its own — add the `{collection_index_summaries}` [prompt variable](../prompt_variables.md) to that node's prompt so the chatbot knows to search it.
+
 ## Which should I use?
 
 In OCS, there are two types of indexes:

--- a/docs/concepts/pipelines/nodes.md
+++ b/docs/concepts/pipelines/nodes.md
@@ -16,11 +16,12 @@ graph LR
 
 A conversational node using AI models. You can configure:
 
-- A [prompt](../llm.md#prompt) for instructions on how to respond and using [prompt variables](../prompt_variables.md) to insert dynamic content
+- A [prompt](../llm.md#prompt) for instructions on how to respond
+- [Prompt variables](../prompt_variables.md) to insert dynamic content
 - A [history mode](history.md) for conversation memory
 - [Temperature and effort parameters](../../how-to/adjust_llm_node_model_parameters.md) to shape output style and depth
 - [Tools](../tools/index.md) for additional actions
-- [Collections](../collections/index.md) — select from your already-created collections: an indexed collection to search your documents and ground responses (RAG), or a media collection to send files to participants. Collections must be created first — see [Adding a collection to a chatbot](../collections/index.md#adding-a-collection-to-a-chatbot).
+- [Collections](../collections/index.md) for indexed collections to ground responses in your documents (RAG), or a media collections to send files to participants.
 - [Custom Actions](../llm_custom_action.md) to connect to external systems and retrieve information or complete tasks
 
 ## Routing Nodes

--- a/docs/concepts/pipelines/nodes.md
+++ b/docs/concepts/pipelines/nodes.md
@@ -46,11 +46,11 @@ See the [Render a Template and Send an Email Node](../../tech-hub/template_and_e
 
 ## Extract Structured Data Node
 
-Extract structured data from the input. This node acts as a passthrough: its output is identical to its input, so it can be used in a pipeline without affecting the conversation.
+Extract structured data from the input. This node acts as a passthrough, meaning the output will be identical to the input, allowing it to be used in a pipeline without affecting the conversation.
 
 ## Update Participant Data Node
 
-Extracts structured data from the input and saves it as participant data. This node is commonly used with [events](../events.md).
+Extract structured data and save it as participant data. This node is commonly used with [events](../events.md).
 
 ## Python Node
 

--- a/docs/concepts/pipelines/nodes.md
+++ b/docs/concepts/pipelines/nodes.md
@@ -25,19 +25,6 @@ A conversational node using AI models. You can configure this node.
 Routers are used to reduce cost, improve accuracy, and keep pipeline workflows flexible. A router will: receive input, analyze it, choose the next workflow step, and pass the request to the downstream node.
 See the [Router Node](./router_nodes.md) page for full details.
 
-## Python Node
-
-Execute custom Python code for logic, data processing, or external API calls.
-
-**Key capabilities:**
-
-- **[Utility functions](../../tech-hub/python_node.md#utility-functions)** — read and write [participant data](../../concepts/participant_data.md), [temporary state](../../tech-hub/python_node.md#temporary-state) (per pipeline run), and [session state](../../tech-hub/python_node.md#session-state) (per user session).
-- **[Attachments](../../tech-hub/python_node.md#attachments)** — access files uploaded by the user and read their contents (text, PDF, DOCX, XLSX, and [more](../../tech-hub/python_node.md#supported-file-types)).
-- **[HTTP client](../../tech-hub/external-api-calls/http_client.md)** — make secure HTTP requests to external APIs using the built-in `http` global.
-- **[Debugging](../../tech-hub/python_node.md#debugging-with-print)** — use `print()` to capture diagnostic output, visible in the trace detail view.
-
-See the [Python Node](../../tech-hub/python_node.md) page for full documentation.
-
 ## Render a Template Node
 
 The Render a Template node lets you shape the text flowing through a pipeline before it reaches the next step. You write a template that mixes fixed text with placeholders — the node fills in those placeholders at runtime using information about the current message, the participant, and the pipeline state.
@@ -59,3 +46,16 @@ Extract structured data from the input. This node acts as a passthrough, meaning
 
 ## Update Participant Data Node
 Extract structured data and save it as participant data. This node is commonly used with [events](../events.md).
+
+## Python Node
+
+Execute custom Python code for logic, data processing, or external API calls.
+
+**Key capabilities:**
+
+- **[Utility functions](../../tech-hub/python_node.md#utility-functions)** — read and write [participant data](../../concepts/participant_data.md), [temporary state](../../tech-hub/python_node.md#temporary-state) (per pipeline run), and [session state](../../tech-hub/python_node.md#session-state) (per user session).
+- **[Attachments](../../tech-hub/python_node.md#attachments)** — access files uploaded by the user and read their contents (text, PDF, DOCX, XLSX, and [more](../../tech-hub/python_node.md#supported-file-types)).
+- **[HTTP client](../../tech-hub/external-api-calls/http_client.md)** — make secure HTTP requests to external APIs using the built-in `http` global.
+- **[Debugging](../../tech-hub/python_node.md#debugging-with-print)** — use `print()` to capture diagnostic output, visible in the trace detail view.
+
+See the [Python Node](../../tech-hub/python_node.md) page for full documentation.

--- a/docs/concepts/pipelines/nodes.md
+++ b/docs/concepts/pipelines/nodes.md
@@ -19,6 +19,8 @@ A conversational node using AI models. You can configure this node.
 - A [history mode](history.md) for conversation memory
 - [Temperature and effort parameters](../../how-to/adjust_llm_node_model_parameters.md) to shape output style and depth
 - [Tools](../tools/index.md) for additional actions
+- [Collections](../collections/index.md) — reference and search an indexed collection to ground responses in your documents (RAG), or send files to participants from a media collection
+- [Custom Actions](../llm_custom_action.md) — connect to external systems to retrieve information or complete tasks
 
 ## Routing Nodes
 

--- a/docs/concepts/pipelines/nodes.md
+++ b/docs/concepts/pipelines/nodes.md
@@ -4,8 +4,8 @@ A node is a discrete processing step in a [pipeline](index.md) that accepts a us
 
 ```mermaid
 graph LR
-  A@{ shape: stadium, label: "Input (ie data or prompt)" } --> B(Node);
-  B --> C@{ shape: stadium, label: "Output (ie LLM response)" };
+  A@{ shape: stadium, label: "Input (i.e. data or prompt)" } --> B(Node);
+  B --> C@{ shape: stadium, label: "Output (i.e. LLM response)" };
 ```
 
 !!! note Examples
@@ -13,18 +13,19 @@ graph LR
     See [chatbot workflow cookbook](../../how-to/workflow_cookbook.md) for examples of pipelines using different combinations of these node types.
 
 ## LLM Node
-A conversational node using AI models. You can configure this node.
+
+A conversational node using AI models. You can configure:
 
 - A [prompt](../llm.md#prompt) for instructions on how to respond
 - A [history mode](history.md) for conversation memory
 - [Temperature and effort parameters](../../how-to/adjust_llm_node_model_parameters.md) to shape output style and depth
 - [Tools](../tools/index.md) for additional actions
-- [Collections](../collections/index.md) — reference and search an indexed collection to ground responses in your documents (RAG), or send files to participants from a media collection
-- [Custom Actions](../llm_custom_action.md) — connect to external systems to retrieve information or complete tasks
+- [Collections](../collections/index.md) to search an indexed collection and ground responses in your documents (RAG), or send files to participants from a media collection
+- [Custom Actions](../llm_custom_action.md) to connect to external systems and retrieve information or complete tasks
 
 ## Routing Nodes
 
-Routers are used to reduce cost, improve accuracy, and keep pipeline workflows flexible. A router will: receive input, analyze it, choose the next workflow step, and pass the request to the downstream node.
+Routers are used to reduce cost, improve accuracy, and keep pipeline workflows flexible. A router will receive input, analyze it, choose the next workflow step, and pass the request to the downstream node.
 See the [Router Node](./router_nodes.md) page for full details.
 
 ## Render a Template Node
@@ -44,10 +45,12 @@ See the [Send an Email How-to Guide](../../how-to/send_email_node.md) for steps 
 See the [Render a Template and Send an Email Node](../../tech-hub/template_and_email_nodes.md#send-an-email-node) reference for recipient field syntax, template variables, and prompt examples.
 
 ## Extract Structured Data Node
-Extract structured data from the input. This node acts as a passthrough, meaning the output will be identical to the input, allowing it to be used in a pipeline without affecting the conversation.
+
+Extract structured data from the input. This node acts as a passthrough: its output is identical to its input, so it can be used in a pipeline without affecting the conversation.
 
 ## Update Participant Data Node
-Extract structured data and save it as participant data. This node is commonly used with [events](../events.md).
+
+Extracts structured data from the input and saves it as participant data. This node is commonly used with [events](../events.md).
 
 ## Python Node
 

--- a/docs/concepts/pipelines/nodes.md
+++ b/docs/concepts/pipelines/nodes.md
@@ -16,11 +16,11 @@ graph LR
 
 A conversational node using AI models. You can configure:
 
-- A [prompt](../llm.md#prompt) for instructions on how to respond
+- A [prompt](../llm.md#prompt) for instructions on how to respond and using [prompt variables](../prompt_variables.md) to insert dynamic content
 - A [history mode](history.md) for conversation memory
 - [Temperature and effort parameters](../../how-to/adjust_llm_node_model_parameters.md) to shape output style and depth
 - [Tools](../tools/index.md) for additional actions
-- [Collections](../collections/index.md) to search an indexed collection and ground responses in your documents (RAG), or send files to participants from a media collection
+- [Collections](../collections/index.md) — select from your already-created collections: an indexed collection to search your documents and ground responses (RAG), or a media collection to send files to participants. Collections must be created first — see [Adding a collection to a chatbot](../collections/index.md#adding-a-collection-to-a-chatbot).
 - [Custom Actions](../llm_custom_action.md) to connect to external systems and retrieve information or complete tasks
 
 ## Routing Nodes

--- a/docs/concepts/prompt_variables.md
+++ b/docs/concepts/prompt_variables.md
@@ -10,6 +10,7 @@ The following variables are currently supported:
 - `{participant_data}` - Information specific to this participant, bot and channel. See [here][participant_data] for more information.
 - `{current_datetime}` - This refers to the date and time at which the response is generated.
 - `{media}` - (pipelines only) This refers to the linked [media collection](./collections/media.md).
+- `{collection_index_summaries}` This refers to the [indexed collections](./collections/indexed.md)
 - `{temp_state}` - (pipelines only) Access to the pipeline temporary state. See [Temporary State](../tech-hub/python_node.md#temporary-state).
 - `{session_state}` - (pipelines only) Access to the session state. See [Session State](../tech-hub/python_node.md#session-state)
 

--- a/docs/concepts/prompt_variables.md
+++ b/docs/concepts/prompt_variables.md
@@ -10,7 +10,7 @@ The following variables are currently supported:
 - `{participant_data}` - Information specific to this participant, bot and channel. See [here][participant_data] for more information.
 - `{current_datetime}` - This refers to the date and time at which the response is generated.
 - `{media}` - (pipelines only) This refers to the linked [media collection](./collections/media.md).
-- `{collection_index_summaries}` This refers to the [indexed collections](./collections/indexed.md)
+- `{collection_index_summaries}` - This refers to the [indexed collections](./collections/indexed.md).
 - `{temp_state}` - (pipelines only) Access to the pipeline temporary state. See [Temporary State](../tech-hub/python_node.md#temporary-state).
 - `{session_state}` - (pipelines only) Access to the session state. See [Session State](../tech-hub/python_node.md#session-state)
 


### PR DESCRIPTION
### Background

As a new user to the **Indexed collections** feature, I was confused as how i would use the collections that I had created in pipeline nodes.
The use of media collections was clearer.

### Done

- Enhanced section on "Adding a collection to a chatbot"
- prompt variable of `{collection_index_summaries}` was **missing** from user docs - now added in a few places
- more internal links added from nodes and prompt variable pages to Collection pages

#### Small other changes

- For findabiliy of useful node types on Nodes page, moved Python node to bottom of page as will be used less often
- grammar and readablity also improved