### PR TITLE
Let @claude run the zensical build

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -45,4 +56,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr create:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Read,Write,Edit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr create:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(uv run zensical build:*),Bash(uv run zensical serve:*),Bash(uv sync:*),Bash(uv run pytest:*),Read,Write,Edit"


### PR DESCRIPTION
The `@claude` workflow could edit docs but had no toolchain, so it couldn't verify its own changes build. Now it installs Python + uv + deps (matching `ci.yml`) and is allowed to run `uv run zensical build`/`serve`/`pytest` and `uv sync`, so it can catch broken links before pushing.