### PR TITLE
Reduce technical information on OpenAI remote index collections limit

### DIFF
--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -45,7 +45,7 @@ Remote indexes are hosted and managed by your LLM provider. Files are uploaded t
 
 !!! warning "OpenAI Remote Collection Limit"
 
-    When using OpenAI as your LLM provider with remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This is a limitation imposed by OpenAI's API, not Open Chat Studio.
+    When using OpenAI as your LLM provider with remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This limit is hardcoded in Open Chat Studio because engineers found empirically in production that using more than 2 remote collections with OpenAI causes issues. It will remain in place until further testing confirms that a higher number of collections can be used reliably.
 
     - **Local indexes** are NOT affected by this limit
     - **Non-OpenAI providers** are NOT affected by this limit

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -43,11 +43,10 @@ Remote indexes are hosted and managed by your LLM provider. Files are uploaded t
 ### Supported LLM providers
 - OpenAI
 
-!!! warning "OpenAI limit of 2 Remote Index Collections"
+!!! warning "OpenAI limit of 2 remote index collections"
 
-    When using remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This is a limitation imposed by OpenAI itself.
+    When using remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections** when configuring a LLM node.
 
-    - If you attempt to select more than 2 remote collections, OCS will show you a validation error
     - **Local indexes** are NOT affected by this limit — it only applies to OpenAI-hosted remote indexes
     - This limit comes from OpenAI's API, although it's not specifically documented
 

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -40,16 +40,16 @@ If you are new to indexed collections, start with a **Remote Index**. Switch to 
 ## Remote Index
 Remote indexes are hosted and managed by your LLM provider. Files are uploaded to the provider, which handles all indexing. The embedding model is chosen by the provider.
 
-### Supported providers
-- OpenAI (using the [responses API](https://platform.openai.com/docs/api-reference/responses))
+### Supported LLM providers
+- OpenAI
 
-!!! warning "OpenAI Remote Collection Limit"
+!!! warning "OpenAI limit of 2 Remote Index Collections"
 
-    When using OpenAI as your LLM provider with remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This is a limitation imposed by OpenAI itself.
+    When using remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This is a limitation imposed by OpenAI itself.
 
-    - If you attempt to select more than 2 remote collections with OpenAI, OCS will show you a validation error
+    - If you attempt to select more than 2 remote collections, OCS will show you a validation error
     - **Local indexes** are NOT affected by this limit — it only applies to OpenAI-hosted remote indexes
-    - This limit comes from OpenAI's API although it's not specifically documented
+    - This limit comes from OpenAI's API, although it's not specifically documented
 
 ### Supported file types
 Supported files are determined by the selected provider:

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -45,11 +45,12 @@ Remote indexes are hosted and managed by your LLM provider. Files are uploaded t
 
 !!! warning "OpenAI Remote Collection Limit"
 
-    When using OpenAI as your LLM provider with remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This limit is hardcoded in Open Chat Studio because engineers found empirically in production that using more than 2 remote collections with OpenAI causes issues. It will remain in place until further testing confirms that a higher number of collections can be used reliably.
+    When using OpenAI as your LLM provider with remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This is a hard limit imposed by OpenAI itself.
 
-    - **Local indexes** are NOT affected by this limit
-    - **Non-OpenAI providers** are NOT affected by this limit
     - If you attempt to select more than 2 remote collections with OpenAI, you will receive a validation error
+    - **Local indexes** are NOT affected by this limit — it only applies to OpenAI-hosted remote indexes
+    - **Non-OpenAI providers** are NOT affected by this limit
+    - This limit comes from OpenAI's API and won't change unless OpenAI raises it (although it's not specifically documented)
 
 ### Supported file types
 Supported files are determined by the selected provider:

--- a/docs/concepts/collections/indexed.md
+++ b/docs/concepts/collections/indexed.md
@@ -45,12 +45,11 @@ Remote indexes are hosted and managed by your LLM provider. Files are uploaded t
 
 !!! warning "OpenAI Remote Collection Limit"
 
-    When using OpenAI as your LLM provider with remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This is a hard limit imposed by OpenAI itself.
+    When using OpenAI as your LLM provider with remote (OpenAI-hosted) indexed collections, you can select a **maximum of 2 collections per LLM node**. This is a limitation imposed by OpenAI itself.
 
-    - If you attempt to select more than 2 remote collections with OpenAI, you will receive a validation error
+    - If you attempt to select more than 2 remote collections with OpenAI, OCS will show you a validation error
     - **Local indexes** are NOT affected by this limit — it only applies to OpenAI-hosted remote indexes
-    - **Non-OpenAI providers** are NOT affected by this limit
-    - This limit comes from OpenAI's API and won't change unless OpenAI raises it (although it's not specifically documented)
+    - This limit comes from OpenAI's API although it's not specifically documented
 
 ### Supported file types
 Supported files are determined by the selected provider:


### PR DESCRIPTION
### Background

As a user of a remote index, I was confused about the limit of 2 collections per LLM Node as the OpenAI documentation does **not** have a note of this limit.

I had fun investigating this!

On deep investigation, I found that OpenAI Responses API's `file_search` tool searches across multiple vector stores in a single call, but rejects more than 2 — a 3rd `vector_store_id` causes OpenAI's API to return a **400 error** ("maximum of 2 vector stores allowed").

### Done

1. Simplified warning in docs for a user who does not care why there is limit!
2. Added that not documented by OpenAI
3. Removed link to API docs as they DONT show that there is this limit!

I will also add a note to the developer docs about this limit not being documented by OpenAI see:  https://github.com/dimagi/open-chat-studio/pull/3815