### PR TITLE
Split out topics from "Deploying bots to Platforms" as very long

### DIFF
--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-To enable users to interact with your bot through external social media platforms and similar services, OCS integrates with various [messaging providers][1]. This integration allows you to deploy your bot to external platforms. Once a platform is linked to your bot, users can communicate with it through that platform. In OCS, the term "channel" is synonymous with "platform."
+To enable users to interact with your chatbot through external social media platforms and similar services, OCS integrates with various [messaging providers][1]. This integration allows you to deploy your chatbot to external platforms. Once a platform is linked to your chatbot, users can communicate with it through that platform. In OCS, the term "channel" is synonymous with "platform."
 
 The currently supported channels are:
 
@@ -14,12 +14,12 @@ The currently supported channels are:
 
 ## File support
 
-Channels differ in whether users can send files to the bot and whether the bot can send files back. When the bot produces a file that a channel cannot deliver — because the channel doesn't support file sending, or the file's type or size isn't allowed — OCS appends a download link to the bot's message instead, so the user can still get the file.
+Channels differ in whether users can send files to the chatbot and whether the chatbot can send files back. When the chatbot produces a file that a channel cannot deliver — because the channel doesn't support file sending, or the file's type or size isn't allowed — OCS appends a download link to the chatbot's message instead, so the user can still get the file.
 
 | Channel | Users can send files | Bot can send files | Types and limits |
 |---|---|---|---|
 | Web / Chat widget | Yes | As download links | Uploads of up to 50 MB per file (50 MB total per message). Text files are always accepted, along with common document, image, audio and video formats. See the [widget file attachments reference][widget-files] for the full list. |
-| API | Yes | As attachment metadata | Same upload limits as the web channel. Files the bot produces are returned on the message as attachments with download links. |
+| API | Yes | As attachment metadata | Same upload limits as the web channel. Files the chatbot produces are returned on the message as attachments with download links. |
 | Telegram | No | Yes | Outgoing: images up to 10 MB; audio, video and documents up to 50 MB. Photos and documents sent by users are not accepted. |
 | WhatsApp | Yes | Yes | Incoming: images and documents (a caption becomes the message text). Outgoing: images up to 5 MB, audio and video up to 16 MB, documents up to 100 MB. Applies to all providers (Twilio, Turn.io, Meta Cloud API). |
 | Facebook Messenger | No | As download links | No files in either direction; text and voice messages only. |
@@ -31,8 +31,8 @@ Channels differ in whether users can send files to the bot and whether the bot c
     Voice notes are handled separately from file attachments. On channels with voice support (Telegram, WhatsApp and Facebook Messenger), a voice note from the user is transcribed and processed as a regular message rather than being treated as a file.
 
 ## See also
-- [Deploying your bot to different channels](../how-to/deploy_to_different_channels.md)
+- [Deploying your chatbot to different channels](../how-to/deploy_to_different_channels.md)
 
 [1]: ./team/messaging_providers.md
 [widget-files]: ../chat_widget/reference.md#file-attachments
-[email-files]: ../how-to/deploy_to_different_channels.md#file-attachments
+[email-files]: ../how-to/deploy_email_channel.md#file-attachments

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -14,7 +14,7 @@ The currently supported channels are:
 - Facebook Messenger
 - Slack
 - API
-- SureAdhere
+- SureAdhere In-App Messaging
 - Email
 
 ## File support

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -1,9 +1,11 @@
 # Channels
 
-To enable users to interact with your chatbot through external social media platforms and similar services, OCS integrates with various [messaging providers][1]. This integration allows you to deploy your chatbot to external platforms. Once a platform is linked to your chatbot, users can communicate with it through that platform.
+A **channel** is how your chatbot interacts with participants — such as Telegram, WhatsApp, or Slack. Linking a channel lets users chat directly on a platform they already use, instead of requiring them to visit a separate web page.
 
 !!! info "Channel vs. platform"
     OCS uses "channel" and "platform" interchangeably. You'll mostly see "channel" in these docs, but some parts of the OCS UI use the label "Platform" for the same thing.
+
+Some channels work out of the box; others require you to first [configure a messaging provider][1] — the account that handles message delivery for that platform. Once a channel is linked to your chatbot, users can start communicating with it through that platform.
 
 The currently supported channels are:
 

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -19,7 +19,7 @@ The currently supported channels are:
 
 Channels differ in whether users can send files to the chatbot and whether the chatbot can send files back. When the chatbot produces a file that a channel cannot deliver — because the channel doesn't support file sending, or the file's type or size isn't allowed — OCS appends a download link to the chatbot's message instead, so the user can still get the file.
 
-| Channel | Users can send files | Bot can send files | Types and limits |
+| Channel | Users can send files | Chatbot can send files | Types and limits |
 |---|---|---|---|
 | Web / Chat widget | Yes | As download links | Uploads of up to 50 MB per file (50 MB total per message). Text files are always accepted, along with common document, image, audio and video formats. See the [widget file attachments reference][widget-files] for the full list. |
 | API | Yes | As attachment metadata | Same upload limits as the web channel. Files the chatbot produces are returned on the message as attachments with download links. |

--- a/docs/concepts/channels.md
+++ b/docs/concepts/channels.md
@@ -1,6 +1,9 @@
 # Channels
 
-To enable users to interact with your chatbot through external social media platforms and similar services, OCS integrates with various [messaging providers][1]. This integration allows you to deploy your chatbot to external platforms. Once a platform is linked to your chatbot, users can communicate with it through that platform. In OCS, the term "channel" is synonymous with "platform."
+To enable users to interact with your chatbot through external social media platforms and similar services, OCS integrates with various [messaging providers][1]. This integration allows you to deploy your chatbot to external platforms. Once a platform is linked to your chatbot, users can communicate with it through that platform.
+
+!!! info "Channel vs. platform"
+    OCS uses "channel" and "platform" interchangeably. You'll mostly see "channel" in these docs, but some parts of the OCS UI use the label "Platform" for the same thing.
 
 The currently supported channels are:
 

--- a/docs/concepts/collections/media.md
+++ b/docs/concepts/collections/media.md
@@ -62,7 +62,7 @@ By default, attachments are sent as download links appended to the chatbot’s m
 
 * Telegram
 * WhatsApp (Turn.io provider)
-* SureAdhere
+* SureAdhere Mobile App
 * Facebook Messenger
 * Slack
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -37,7 +37,7 @@ For step-by-step instructions on completing specific tasks, see the [How-to guid
 : Reusable connections to external services that let your chatbot retrieve information or complete tasks in another system — such as looking up an order status or creating a support ticket.
 
 [Evaluations](evaluations/index.md)
-: A built-in testing system that runs your chatbot against sample conversations and scores the responses against criteria you define, such as accuracy, tone, or whether the bot stayed on topic.
+: A built-in testing system that runs your chatbot against sample conversations and scores the responses against criteria you define, such as accuracy, tone, or whether the chatbot stayed on topic.
 
 [Events](events.md)
 : Automated actions that fire when something specific happens in a chatbot session — for example, when a conversation starts, ends, or when a participant has been inactive for a set period.
@@ -46,7 +46,7 @@ For step-by-step instructions on completing specific tasks, see the [How-to guid
 : The AI model that powers your chatbot's ability to understand messages and generate responses. OCS lets you choose from a range of models and configure how they behave.
 
 [Messaging Provider](team/messaging_providers.md)
-: A communication platform — such as Facebook, Telegram, Twilio or Slack — for chatbots to use as a channel to interact with participants.
+: An provider account you configure for a messaging service — such as Twilio, Turn.io, or Slack — that some channels require in order to send and receive messages for your chatbot.
 
 [Node](./pipelines/nodes.md)
 : A single processing step in a pipeline. Each node performs one task, such as calling an LLM, running custom code, or routing the conversation based on its content.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -46,7 +46,7 @@ For step-by-step instructions on completing specific tasks, see the [How-to guid
 : The AI model that powers your chatbot's ability to understand messages and generate responses. OCS lets you choose from a range of models and configure how they behave.
 
 [Messaging Provider](team/messaging_providers.md)
-: A communication platform — such as WhatsApp or Slack — for chatbots to use as a channel to interact with participants.
+: A communication platform — such as Facebook, Twilio or Slack — for chatbots to use as a channel to interact with participants.
 
 [Node](./pipelines/nodes.md)
 : A single processing step in a pipeline. Each node performs one task, such as calling an LLM, running custom code, or routing the conversation based on its content.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -22,7 +22,7 @@ For step-by-step instructions on completing specific tasks, see the [How-to guid
 : Credentials — such as API keys, bearer tokens, or username/password pairs — used when your chatbot connects to external services via Custom Actions or Python nodes.
 
 [Channel](channels.md)
-: The platform through which a participant interacts with your chatbot — for example, WhatsApp, Telegram, the web, or Slack.
+: How a participant interacts with your chatbot — for example, WhatsApp, Telegram, the web, or Slack.
 
 [Chatbot](chatbots/index.md)
 : In OCS, this is the top-level configuration for your conversational experience. It defines the chatbot's behavior, connects it to one or more channels, and is published to participants.
@@ -46,7 +46,7 @@ For step-by-step instructions on completing specific tasks, see the [How-to guid
 : The AI model that powers your chatbot's ability to understand messages and generate responses. OCS lets you choose from a range of models and configure how they behave.
 
 [Messaging Provider](team/messaging_providers.md)
-: A connection to a communication platform — such as WhatsApp or Slack — so chatbots can be deployed to that service.
+: A communication platform — such as WhatsApp or Slack — for chatbots to use as a channel to interact with participants.
 
 [Node](./pipelines/nodes.md)
 : A single processing step in a pipeline. Each node performs one task, such as calling an LLM, running custom code, or routing the conversation based on its content.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -46,7 +46,7 @@ For step-by-step instructions on completing specific tasks, see the [How-to guid
 : The AI model that powers your chatbot's ability to understand messages and generate responses. OCS lets you choose from a range of models and configure how they behave.
 
 [Messaging Provider](team/messaging_providers.md)
-: A communication platform — such as Facebook, Twilio or Slack — for chatbots to use as a channel to interact with participants.
+: A communication platform — such as Facebook, Telegram, Twilio or Slack — for chatbots to use as a channel to interact with participants.
 
 [Node](./pipelines/nodes.md)
 : A single processing step in a pipeline. Each node performs one task, such as calling an LLM, running custom code, or routing the conversation based on its content.

--- a/docs/concepts/team/messaging_providers.md
+++ b/docs/concepts/team/messaging_providers.md
@@ -1,20 +1,21 @@
 # Messaging Providers
 
-Messaging providers offer access to communication platforms such as WhatsApp, Facebook Messenger, Slack, and more. Connecting a chatbot to these services allows users to interact with the bot on the respective service.
+Messaging providers offer access to platforms such as WhatsApp, Facebook Messenger, Slack, and more.
+Configuring a messaging provider lets you use the channel for your chatbot, so users can interact with it there.
 
 ## Supported providers
 
-Below is a list of supported providers and their integrated platforms in OCS:
+Below is a list of supported messaging platforms in OCS:
 
-- Twilio
+- **Twilio**
     - WhatsApp
     - Facebook Messenger
-- Turn.io
+- **Turn.io**
     - WhatsApp
-- Meta Cloud API
+- **Meta Cloud API**
     - WhatsApp
-- Slack
-- SureAdhere
+- **Slack**
+- **SureAdhere mobile app**
 
 ## Choosing a WhatsApp provider
 
@@ -33,5 +34,6 @@ Open Chat Studio supports three WhatsApp providers. The table below summarises t
 Use **Meta Cloud API** when you want a direct connection to the WhatsApp Business Platform without routing traffic through a third-party service. Use **Twilio** or **Turn.io** when you already have an account with one of those providers.
 
 ## See also
+- [Channels](../channels.md)
 - [Configure a messaging provider](../../tutorials/configure_msg_providers.md)
 - [Deploy to WhatsApp via Meta Cloud API](../../how-to/whatsapp_meta_cloud_api.md)

--- a/docs/concepts/team/messaging_providers.md
+++ b/docs/concepts/team/messaging_providers.md
@@ -1,11 +1,11 @@
 # Messaging Providers
 
-Messaging providers offer access to platforms such as WhatsApp, Facebook Messenger, Slack, and more.
+Messaging providers offer access to communication channels such as WhatsApp, Facebook Messenger, Slack, and more.
 Configuring a messaging provider lets you use the channel for your chatbot, so users can interact with it there.
 
 ## Supported providers
 
-Below is a list of supported messaging platforms in OCS:
+Below is a list of supported providers and their channels:
 
 - **Twilio**
     - WhatsApp
@@ -16,6 +16,7 @@ Below is a list of supported messaging platforms in OCS:
     - WhatsApp
 - **Slack**
 - **SureAdhere mobile app**
+    - In-App secure messaging
 
 ## Choosing a WhatsApp provider
 

--- a/docs/how-to/deploy_email_channel.md
+++ b/docs/how-to/deploy_email_channel.md
@@ -1,0 +1,59 @@
+# Deploy Your Chatbot to Email
+
+The email channel lets users interact with your chatbot by sending and receiving emails.
+
+## Configuration
+
+When creating an email channel, the form has the following fields:
+
+- **Email address**: The inbound address that users send messages to. Incoming emails addressed to this value are routed to this chatbot.
+- **From address**: The address that appears in the "From" field of outgoing replies.
+- **Default channel**: When enabled, this channel acts as the fallback for inbound emails that do not match any other configured email address in your workspace.
+
+!!! info "Note"
+    Only one email channel per workspace can be set as the default.
+
+## How routing works
+
+Inbound emails are matched to the correct chatbot in this order:
+
+1. **In-Reply-To header** - If the email is a reply to a previous message sent by the chatbot, it is routed to the same channel and continues the existing conversation thread.
+2. **To address** - If no prior thread is found, the recipient address is matched against configured email channels.
+3. **Default channel** - If no address match is found, the email is delivered to the workspace's default email channel (if one is configured).
+
+## Thread continuity
+
+Replying to a chatbot email continues the same conversation session. Sending a fresh email to the channel address starts a new session.
+
+## Customizing the outbound subject
+
+When the chatbot starts a new email thread (for example, via the [Trigger chatbot Message](https://www.openchatstudio.com/api/v1/docs/#tag/Channels/operation/trigger_bot_message) API), the subject line defaults to "New message". To override this, set an `email_subject` value in [session state](../tech-hub/python_node.md#session-state) before the email is sent — for example from a pipeline's Python node, or via the `session_data` parameter when triggering the chatbot. Inbound reply threads always reuse the subject of the original email and are unaffected by this value.
+
+## File attachments
+
+The email channel supports bidirectional file attachments. For a comparison of file support across all channels, see [channel file support](../concepts/channels.md#file-support).
+
+### Inbound attachments (user to chatbot)
+
+When a user emails files to the chatbot, each attachment is saved and made available to the LLM or pipeline as a file record. Attachments behave like files uploaded through any other channel: they appear in the `attachments` list in the pipeline's [temporary state](../tech-hub/python_node.md#attachments) and are passed to the LLM for processing.
+
+The following attachments are rejected automatically:
+
+| Rejection reason | How it appears to the chatbot |
+|---|---|
+| File exceeds 20 MB | Bracketed note in the message text, e.g. `[Attachment "report.zip" was rejected: file too large (max 20 MB)]` |
+| Executable file type (e.g. `.exe`, `.sh`) | Bracketed note in the message text |
+| Content-type mismatch (declared MIME type does not match actual file bytes) | Bracketed note in the message text |
+
+Rejection notes are inserted inline into the user's message so the chatbot can read them and explain the problem to the user in its reply.
+
+### Outbound attachments (chatbot to user)
+
+Files produced by the pipeline are sent as MIME attachments in the same threaded reply as the chatbot's text response. From a Python node, call `add_file_attachment()` to attach a file — see the [Python Node documentation](../tech-hub/python_node.md#python_node.add_file_attachment) for the full API reference and example.
+
+If a pipeline-produced file cannot be sent as an attachment (for example, it exceeds the size limit or is a denylisted type), the email body will contain an inline download link for that file instead.
+
+## See also
+
+- [Deploy your chatbot to different platforms](deploy_to_different_channels.md)
+- [Python Node documentation](../tech-hub/python_node.md)

--- a/docs/how-to/deploy_email_channel.md
+++ b/docs/how-to/deploy_email_channel.md
@@ -55,5 +55,5 @@ If a pipeline-produced file cannot be sent as an attachment (for example, it exc
 
 ## See also
 
-- [Deploy your chatbot to different platforms](deploy_to_different_channels.md)
+- [Deploy your chatbot to different channels](deploy_to_different_channels.md)
 - [Python Node documentation](../tech-hub/python_node.md)

--- a/docs/how-to/deploy_email_channel.md
+++ b/docs/how-to/deploy_email_channel.md
@@ -27,7 +27,7 @@ Replying to a chatbot email continues the same conversation session. Sending a f
 
 ## Customizing the outbound subject
 
-When the chatbot starts a new email thread (for example, via the [Trigger chatbot Message](https://www.openchatstudio.com/api/v1/docs/#tag/Channels/operation/trigger_bot_message) API), the subject line defaults to "New message". To override this, set an `email_subject` value in [session state](../tech-hub/python_node.md#session-state) before the email is sent — for example from a pipeline's Python node, or via the `session_data` parameter when triggering the chatbot. Inbound reply threads always reuse the subject of the original email and are unaffected by this value.
+When the chatbot starts a new email thread (for example, via the [Trigger bot Message](https://www.openchatstudio.com/api/v1/docs/#tag/Channels/operation/trigger_bot_message) API), the subject line defaults to "New message". To override this, set an `email_subject` value in [session state](../tech-hub/python_node.md#session-state) before the email is sent — for example from a pipeline's Python node, or via the `session_data` parameter when triggering the chatbot. Inbound reply threads always reuse the subject of the original email and are unaffected by this value.
 
 ## File attachments
 

--- a/docs/how-to/deploy_slack_channel.md
+++ b/docs/how-to/deploy_slack_channel.md
@@ -1,10 +1,10 @@
 # Deploy Your Chatbot to Slack
 
-The Slack channel lets users interact with your chatbot directly from Slack, either in specific channels or by mentioning the chatbot.
+Users can interact with your chatbot directly from Slack, either in specific Slack channels or by mentioning the chatbot.
 
 ## Prerequisites
 
-Before configuring a Slack channel for your chatbot, you need to set up a Slack messaging provider. This requires:
+Before configuring a Slack for your chatbot, you need to set up a Slack [messaging provider](../concepts/team/messaging_providers.md). This requires:
 
 - Admin access to your Slack workspace
 - Following the Slack OAuth and application installation flow

--- a/docs/how-to/deploy_slack_channel.md
+++ b/docs/how-to/deploy_slack_channel.md
@@ -45,7 +45,7 @@ Once the channel is linked, users interact with the chatbot by mentioning it in 
 
 ## See also
 
-- [Deploy your chatbot to different platforms](deploy_to_different_channels.md)
+- [Deploy your chatbot to different channels](deploy_to_different_channels.md)
 - [Configure a messaging provider][6]
 
 [6]: ../tutorials/configure_msg_providers.md

--- a/docs/how-to/deploy_slack_channel.md
+++ b/docs/how-to/deploy_slack_channel.md
@@ -4,7 +4,7 @@ Users can interact with your chatbot directly from Slack, either in specific Sla
 
 ## Prerequisites
 
-Before configuring a Slack for your chatbot, you need to set up a Slack [messaging provider](../concepts/team/messaging_providers.md). This requires:
+Before configuring a Slack channel for your chatbot, you need to set up a Slack [messaging provider](../concepts/team/messaging_providers.md). This requires:
 
 - Admin access to your Slack workspace
 - Following the Slack OAuth and application installation flow
@@ -17,20 +17,20 @@ Once your Slack messaging provider is configured, you can link channels to your 
 There are three different ways to configure how your chatbot responds to messages in Slack. The chatbot checks each configuration in order of priority:
 
 ### 1. Respond to messages from a single channel (highest priority)
-    - Specify the channel name (with or without the '#' prefix) in the channel configuration form.
-    - This is the highest specificity - messages on this channel will only be responded to by this chatbot.
-    - Only one chatbot can be configured per Slack channel.
+- Specify the channel name (with or without the '#' prefix) in the channel configuration form.
+- This is the highest specificity - messages on this channel will only be responded to by this chatbot.
+- Only one chatbot can be configured per Slack channel.
 
 ### 2. Respond to messages from any channel using keyword matching
-    - Enter keywords separated by commas in the keyword field (e.g., `support, help, assistance`).
-    - Keywords are matched using exact word matching (case-insensitive) to the first word of the user's message.
-    - Multiple keywords can be used to trigger the chatbot.
-    - Keywords must be unique to this chatbot & Slack workspace combination.
+- Enter keywords separated by commas in the keyword field (e.g., `support, help, assistance`).
+- Keywords are matched using exact word matching (case-insensitive) to the first word of the user's message.
+- Multiple keywords can be used to trigger the chatbot.
+- Keywords must be unique to this chatbot & Slack workspace combination.
 
 ### 3. Respond to messages from all channels (lowest priority)
-    - The chatbot will respond to any message on any channel if it hasn't matched one of the previous two configurations.
-    - This is the lowest priority matching option.
-    - Only one chatbot per Slack workspace can be configured with this option.
+- The chatbot will respond to any message on any channel if it hasn't matched one of the previous two configurations.
+- This is the lowest priority matching option.
+- Only one chatbot per Slack workspace can be configured with this option.
 
 ## Chatbot Interaction
 

--- a/docs/how-to/deploy_slack_channel.md
+++ b/docs/how-to/deploy_slack_channel.md
@@ -1,0 +1,51 @@
+# Deploy Your Chatbot to Slack
+
+The Slack channel lets users interact with your chatbot directly from Slack, either in specific channels or by mentioning the chatbot.
+
+## Prerequisites
+
+Before configuring a Slack channel for your chatbot, you need to set up a Slack messaging provider. This requires:
+
+- Admin access to your Slack workspace
+- Following the Slack OAuth and application installation flow
+- Configuring the messaging provider in Open Chat Studio (see [Configure a messaging provider][6])
+
+Once your Slack messaging provider is configured, you can link channels to your chatbot.
+
+## Configuration Options
+
+There are three different ways to configure how your chatbot responds to messages in Slack. The chatbot checks each configuration in order of priority:
+
+### 1. Respond to messages from a single channel (highest priority)
+    - Specify the channel name (with or without the '#' prefix) in the channel configuration form.
+    - This is the highest specificity - messages on this channel will only be responded to by this chatbot.
+    - Only one chatbot can be configured per Slack channel.
+
+### 2. Respond to messages from any channel using keyword matching
+    - Enter keywords separated by commas in the keyword field (e.g., `support, help, assistance`).
+    - Keywords are matched using exact word matching (case-insensitive) to the first word of the user's message.
+    - Multiple keywords can be used to trigger the chatbot.
+    - Keywords must be unique to this chatbot & Slack workspace combination.
+
+### 3. Respond to messages from all channels (lowest priority)
+    - The chatbot will respond to any message on any channel if it hasn't matched one of the previous two configurations.
+    - This is the lowest priority matching option.
+    - Only one chatbot per Slack workspace can be configured with this option.
+
+## Chatbot Interaction
+
+Once the channel is linked, users interact with the chatbot by mentioning it in Slack messages. The chatbot mention name is determined by your Slack app configuration. For example, on the Dimagi hosted instance of Open Chat Studio, the chatbot is mentioned using `@Dimagi Bots`.
+
+!!! info "Priority and Precedence"
+    If multiple chatbots could match a message, the chatbot with the most specific configuration wins:
+
+    1. Single channel configuration (highest priority)
+    2. Keyword matching
+    3. Respond to all channels (lowest priority)
+
+## See also
+
+- [Deploy your chatbot to different platforms](deploy_to_different_channels.md)
+- [Configure a messaging provider][6]
+
+[6]: ../tutorials/configure_msg_providers.md

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -62,49 +62,9 @@ See the [Meta Cloud API setup guide][meta] for full step-by-step instructions.
 
 ## Slack
 
-### Prerequisites
+The Slack channel lets users interact with your chatbot from Slack, either in specific channels, via keyword matching, or by mentioning the chatbot workspace-wide.
 
-Before configuring a Slack channel for your chatbot, you need to set up a Slack messaging provider. This requires:
-
-- Admin access to your Slack workspace
-- Following the Slack OAuth and application installation flow
-- Configuring the messaging provider in Open Chat Studio (see [Configure a messaging provider][6])
-
-Once your Slack messaging provider is configured, you can link channels to your chatbot.
-
-### Configuration Options
-
-There are three different ways to configure how your chatbot responds to messages in Slack. The chatbot will check each configuration in order of priority:
-
-### 1. Respond to messages from a single channel (Highest Priority)
-
-- Specify the channel name (with or without the '#' prefix) in the channel configuration form.
-- This is the highest specificity - messages on this channel will only be responded to by this chatbot.
-- Only one chatbot can be configured per Slack channel.
-
-### 2. Respond to messages from any channel using keyword matching
-
-- Enter keywords separated by commas in the keyword field (e.g., `support, help, assistance`).
-- Keywords are matched using exact word matching (case-insensitive) to the first word of the user's message.
-- Multiple keywords can be used to trigger the chatbot.
-- Keywords must be unique to this chatbot & Slack workspace combination.
-
-### 3. Respond to messages from all channels (Lowest Priority)
-
-- The chatbot will respond to any message on any channel if it hasn't matched one of the previous two configurations.
-- This is the lowest priority matching option.
-- Only one chatbot per Slack workspace can be configured with this option.
-
-### chatbot Interaction
-
-Once the channel is linked, users interact with the chatbot by mentioning it in Slack messages. The chatbot mention name is determined by your Slack app configuration. For example, on the Dimagi hosted instance of Open Chat Studio, the chatbot is mentioned using `@Dimagi Bots`.
-
-!!! info "Priority and Precedence"
-    If multiple chatbots could match a message, the chatbot with the most specific configuration wins:
-
-    1. Single channel configuration (highest priority)
-    2. Keyword matching
-    3. Respond to all channels (lowest priority)
+See the [Slack channel guide](deploy_slack_channel.md) for prerequisites, configuration options, and how chatbot mentions work.
 
 ## SureAdhere
 - Enter the Tenant ID that would have been provided to you when setting up your SureAdhere account.

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -5,14 +5,14 @@ To link a channel to your chatbot:
 1. Navigate to the **Chatbot** you wish to link to a channel.
 2. Click on the :material-plus: (plus) icon and select the [channel][2] from the dropdown.
 3. Complete the form and click **Create**.
-4. Follow the guide below to get the required information for the channel selected.
+4. Follow the guide below to get the required information for your selected channel.
 
 !!! info "The channel you want is not shown in the dropdown"
 
-    You may need to [Configure a messaging provider][6] for the platform before you can select it from the dropdown.
+    You may need to [configure a messaging provider][6] for the platform before you can select it from the dropdown.
     Not all channels require a messaging provider.
 
-## Details for linking to channels
+## Supported Channels
 
 - [Web Embedded Widget](#web) — built-in chat interface, no setup required
 - [Telegram](#telegram)
@@ -33,6 +33,7 @@ The web channel is OCS's built-in chat interface. It's enabled by default for ev
 2. Copy the chatbot token and paste it into the form on OCS. It will look something like this: `4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc`.
 
 !!! info "Note"
+
     Depending on your use case, you probably want to disable group joins for your chatbot on Telegram. Since your Telegram chatbot is public, anyone can add it to a group, which could result in significant costs. To achieve this, use the [setjoingroups][5] setting in BotFather.
 
 ## WhatsApp
@@ -44,6 +45,7 @@ Open Chat Studio supports multiple WhatsApp providers. Choose the section below 
 When you create or edit a WhatsApp channel using a Twilio provider, Open Chat Studio automatically configures the webhook in your Twilio messaging service. When you delete the channel, the webhook is cleared automatically. You do not need to copy or paste any webhook URL.
 
 !!! info "Sandbox numbers and other exceptions"
+
     Automatic webhook configuration is not supported for Twilio sandbox numbers or in cases where OCS cannot reach the Twilio API. If auto-configuration fails, OCS will display manual setup instructions instead. Follow the steps in the [Twilio webhook configuration guide][3] and enter the following webhook URL in your messaging service settings:
 
     `https://openchatstudio.com/channels/whatsapp/incoming_message`
@@ -85,9 +87,9 @@ The email channel lets users interact with your chatbot by sending and receiving
 
 See the [Email channel guide](deploy_email_channel.md) for full setup and configuration details.
 
-## SureAdhere for In-App messaging
+## SureAdhere for In-App Messaging
 
-1. Enter the Tenant ID that would have been provided to you when setting up your SureAdhere account.
+1. Enter the Tenant ID that was provided when you set up your SureAdhere account.
 2. After you submit the form, you will be provided with a webhook URL.
 3. Copy this URL and navigate back to your provider's settings to configure it with this URL.
 

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -20,7 +20,7 @@ To link a channel to your chatbot:
 - [Facebook Messenger](#facebook-messenger)
 - [Slack](#slack)
 - [Email](#email)
-- [SureAdhere](#sureadhere-for-in-app-messaging)
+- [SureAdhere Mobile App](#sureadhere-for-secure-in-app-messaging)
 - [API](#api) — programmatic access, no setup required
 
 ## Web
@@ -87,7 +87,7 @@ The email channel lets users interact with your chatbot by sending and receiving
 
 See the [Email channel guide](deploy_email_channel.md) for full setup and configuration details.
 
-## SureAdhere for In-App Messaging
+## SureAdhere for secure In-App Messaging
 
 1. Enter the Tenant ID that was provided when you set up your SureAdhere account.
 2. After you submit the form, you will be provided with a webhook URL.

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -2,44 +2,44 @@
 
 To link a channel to your chatbot:
 
-!!! info "Note"
-    Not all channels require a provider.
+1. Navigate to the **Chatbot** you wish to link to a channel.
+2. Click on the :material-plus: (plus) icon and select the [channel][2] from the dropdown.
+3. Complete the form and click **Create**.
+4. Follow the guide below to get the required information for the channel selected.
 
-1. Navigate to the **Chatbot** you wish to embed.
-2. Click on the :material-plus: (plus) icon and select the [provider][2] from the dropdown.
-3. Complete the form and click **Create**. Follow the guide below to get the required information for each channel.
+!!! info "The channel you want is not shown in the dropdown"
 
-You may need to [Configure a messaging provider][6] before you will be able to select it from the dropdown.
+    You may need to [Configure a messaging provider][6] for the platform before you can select it from the dropdown.
+    Not all channels require a messaging provider.
 
-## Jump to a channel
+## Details for linking to channels
 
-- [Web](#web) — built-in chat interface, no setup required
+- [Web Embedded Widget](#web) — built-in chat interface, no setup required
 - [Telegram](#telegram)
 - [WhatsApp](#whatsapp) — Twilio, Turn.io, or [Meta Cloud API](#meta-cloud-api)
 - [Facebook Messenger](#facebook-messenger)
 - [Slack](#slack)
 - [Email](#email)
 - [SureAdhere](#sureadhere-for-in-app-messaging)
-- [API](#api) — programmatic access, no channel setup required
+- [API](#api) — programmatic access, no setup required
 
 ## Web
 
-The web channel is OCS's built-in chat interface. It's enabled by default for every chatbot — there's no provider to configure and nothing to link. Embed it on your own site with the [chat widget][chat-widget].
+The web channel is OCS's built-in chat interface. It's enabled by default for every chatbot — there's no provider to configure and nothing to link. Embed it on your own website with the [chat widget][chat-widget].
 
 ## Telegram
-- Follow [this guide][1] to create a Telegram chatbot.
-- Copy the chatbot token and paste it into the form on OCS. It will look something like this: `4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc`.
+
+1. Follow [this guide][1] to create a Telegram chatbot.
+2. Copy the chatbot token and paste it into the form on OCS. It will look something like this: `4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc`.
 
 !!! info "Note"
-    Depending on your usecase, you probably want to disable group joins for your chatbot on Telegram. Since your telegram chatbot is public, anyone can add it to a group, which could end up costing you a lot. To achieve this, use the [setjoingroups][5] setting in BotFather.
+    Depending on your use case, you probably want to disable group joins for your chatbot on Telegram. Since your Telegram chatbot is public, anyone can add it to a group, which could result in significant costs. To achieve this, use the [setjoingroups][5] setting in BotFather.
 
 ## WhatsApp
 
 Open Chat Studio supports multiple WhatsApp providers. Choose the section below that matches the provider you have configured.
 
-### Twilio and Turn.io
-
-#### Twilio
+### Twilio
 
 When you create or edit a WhatsApp channel using a Twilio provider, Open Chat Studio automatically configures the webhook in your Twilio messaging service. When you delete the channel, the webhook is cleared automatically. You do not need to copy or paste any webhook URL.
 
@@ -48,7 +48,7 @@ When you create or edit a WhatsApp channel using a Twilio provider, Open Chat St
 
     `https://openchatstudio.com/channels/whatsapp/incoming_message`
 
-#### Turn.io
+### Turn.io
 
 Turn.io does not support automatic webhook configuration. After adding your WhatsApp number in Open Chat Studio, configure the webhook manually:
 
@@ -65,6 +65,7 @@ Meta Cloud API connects your chatbot directly to the WhatsApp Business Platform 
 See the [Meta Cloud API setup guide][meta] for full step-by-step instructions.
 
 ## Facebook Messenger
+
 !!! info "Note"
     It is assumed that you already have a Facebook page and a Twilio account with the Facebook page linked. Follow [this guide][4] if this is not the case.
 
@@ -85,8 +86,10 @@ The email channel lets users interact with your chatbot by sending and receiving
 See the [Email channel guide](deploy_email_channel.md) for full setup and configuration details.
 
 ## SureAdhere for In-App messaging
-- Enter the Tenant ID that would have been provided to you when setting up your SureAdhere account.
-- After you submit the form, you will be provided with a webhook URL. Copy this URL and navigate back to your provider's settings to configure it with this URL.
+
+1. Enter the Tenant ID that would have been provided to you when setting up your SureAdhere account.
+2. After you submit the form, you will be provided with a webhook URL.
+3. Copy this URL and navigate back to your provider's settings to configure it with this URL.
 
 ## API
 

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -1,6 +1,6 @@
-# Deploy your bot to different platforms
+# Deploy your chatbot to different platforms
 
-To link a channel to your bot:
+To link a channel to your chatbot:
 
 !!! info "Note"
     Not all channels require a provider.
@@ -12,14 +12,14 @@ To link a channel to your bot:
 You may need to [Configure a messaging provider][6] before you will be able to select it from the dropdown.
 
 ## Web and API
-The web channel uses the web interface and is enabled by default for all bots. Likewise, all bots can be accessed via the [APIs][api].
+The web channel uses the web interface and is enabled by default for all chatbots. Likewise, all chatbots can be accessed via the [APIs][api].
 
 ## Telegram
-- Follow [this guide][1] to create a Telegram bot.
-- Copy the bot token and paste it into the form on OCS. It will look something like this: `4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc`.
+- Follow [this guide][1] to create a Telegram chatbot.
+- Copy the chatbot token and paste it into the form on OCS. It will look something like this: `4839574812:AAFD39kkdpWt3ywyRZergyOLMaJhac60qc`.
 
 !!! info "Note"
-    Depending on your usecase, you probably want to disable group joins for your bot on Telegram. Since your telegram bot is public, anyone can add it to a group, which could end up costing you a lot. To achieve this, use the [setjoingroups][5] setting in BotFather.
+    Depending on your usecase, you probably want to disable group joins for your chatbot on Telegram. Since your telegram chatbot is public, anyone can add it to a group, which could end up costing you a lot. To achieve this, use the [setjoingroups][5] setting in BotFather.
 
 ## WhatsApp
 
@@ -64,43 +64,43 @@ See the [Meta Cloud API setup guide][meta] for full step-by-step instructions.
 
 ### Prerequisites
 
-Before configuring a Slack channel for your bot, you need to set up a Slack messaging provider. This requires:
+Before configuring a Slack channel for your chatbot, you need to set up a Slack messaging provider. This requires:
 
 - Admin access to your Slack workspace
 - Following the Slack OAuth and application installation flow
 - Configuring the messaging provider in Open Chat Studio (see [Configure a messaging provider][6])
 
-Once your Slack messaging provider is configured, you can link channels to your bot.
+Once your Slack messaging provider is configured, you can link channels to your chatbot.
 
 ### Configuration Options
 
-There are three different ways to configure how your bot responds to messages in Slack. The bot will check each configuration in order of priority:
+There are three different ways to configure how your chatbot responds to messages in Slack. The chatbot will check each configuration in order of priority:
 
 ### 1. Respond to messages from a single channel (Highest Priority)
 
 - Specify the channel name (with or without the '#' prefix) in the channel configuration form.
-- This is the highest specificity - messages on this channel will only be responded to by this bot.
-- Only one bot can be configured per Slack channel.
+- This is the highest specificity - messages on this channel will only be responded to by this chatbot.
+- Only one chatbot can be configured per Slack channel.
 
 ### 2. Respond to messages from any channel using keyword matching
 
 - Enter keywords separated by commas in the keyword field (e.g., `support, help, assistance`).
 - Keywords are matched using exact word matching (case-insensitive) to the first word of the user's message.
-- Multiple keywords can be used to trigger the bot.
-- Keywords must be unique to this bot & Slack workspace combination.
+- Multiple keywords can be used to trigger the chatbot.
+- Keywords must be unique to this chatbot & Slack workspace combination.
 
 ### 3. Respond to messages from all channels (Lowest Priority)
 
-- The bot will respond to any message on any channel if it hasn't matched one of the previous two configurations.
+- The chatbot will respond to any message on any channel if it hasn't matched one of the previous two configurations.
 - This is the lowest priority matching option.
-- Only one bot per Slack workspace can be configured with this option.
+- Only one chatbot per Slack workspace can be configured with this option.
 
-### Bot Interaction
+### chatbot Interaction
 
-Once the channel is linked, users interact with the bot by mentioning it in Slack messages. The bot mention name is determined by your Slack app configuration. For example, on the Dimagi hosted instance of Open Chat Studio, the bot is mentioned using `@Dimagi Bots`.
+Once the channel is linked, users interact with the chatbot by mentioning it in Slack messages. The chatbot mention name is determined by your Slack app configuration. For example, on the Dimagi hosted instance of Open Chat Studio, the chatbot is mentioned using `@Dimagi Bots`.
 
 !!! info "Priority and Precedence"
-    If multiple bots could match a message, the bot with the most specific configuration wins:
+    If multiple chatbots could match a message, the chatbot with the most specific configuration wins:
 
     1. Single channel configuration (highest priority)
     2. Keyword matching
@@ -112,74 +112,9 @@ Once the channel is linked, users interact with the bot by mentioning it in Slac
 
 ## Email
 
-The email channel lets users interact with your bot by sending and receiving emails.
+The email channel lets users interact with your chatbot by sending and receiving emails, including routing, thread continuity, and file attachments.
 
-### Configuration
-
-When creating an email channel, the form has the following fields:
-
-- **Email address**: The inbound address that users send messages to. Incoming emails addressed to this value are routed to this bot.
-- **From address**: The address that appears in the "From" field of outgoing replies.
-- **Default channel**: When enabled, this channel acts as the fallback for inbound emails that do not match any other configured email address in your workspace.
-
-!!! info "Note"
-    Only one email channel per workspace can be set as the default.
-
-### How routing works
-
-Inbound emails are matched to the correct bot in this order:
-
-1. **In-Reply-To header** - If the email is a reply to a previous message sent by the bot, it is routed to the same channel and continues the existing conversation thread.
-2. **To address** - If no prior thread is found, the recipient address is matched against configured email channels.
-3. **Default channel** - If no address match is found, the email is delivered to the workspace's default email channel (if one is configured).
-
-### Thread continuity
-
-Replying to a bot email continues the same conversation session. Sending a fresh email to the channel address starts a new session.
-
-### Customizing the outbound subject
-
-When the bot starts a new email thread (for example, via the [Trigger Bot Message](https://www.openchatstudio.com/api/v1/docs/#tag/Channels/operation/trigger_bot_message) API), the subject line defaults to "New message". To override this, set an `email_subject` value in [session state](../tech-hub/python_node.md#session-state) before the email is sent — for example from a pipeline's Python node, or via the `session_data` parameter when triggering the bot. Inbound reply threads always reuse the subject of the original email and are unaffected by this value.
-
-### File attachments
-
-The email channel supports bidirectional file attachments. For a comparison of file support across all channels, see [channel file support](../concepts/channels.md#file-support).
-
-#### Inbound attachments (user to bot)
-
-When a user emails files to the bot, each attachment is saved and made available to the LLM or pipeline as a file record. Attachments behave like files uploaded through any other channel: they appear in the `attachments` list in the pipeline's [temporary state](../tech-hub/python_node.md#attachments) and are passed to the LLM for processing.
-
-The following attachments are rejected automatically:
-
-| Rejection reason | How it appears to the bot |
-|---|---|
-| File exceeds 20 MB | Bracketed note in the message text, e.g. `[Attachment "report.zip" was rejected: file too large (max 20 MB)]` |
-| Executable file type (e.g. `.exe`, `.sh`) | Bracketed note in the message text |
-| Content-type mismatch (declared MIME type does not match actual file bytes) | Bracketed note in the message text |
-
-Rejection notes are inserted inline into the user's message so the bot can read them and explain the problem to the user in its reply.
-
-#### Outbound attachments (bot to user)
-
-Files produced by the pipeline are sent as MIME attachments in the same threaded reply as the bot's text response. To attach a file from a Python node, call `add_file_attachment()`:
-
-```python
-def main(input, **kwargs) -> str:
-    response = http.get("https://api.example.com/report.pdf", auth="reports-api")
-
-    if response["is_success"]:
-        add_file_attachment(
-            filename="report.pdf",
-            content=response["response_bytes"]
-        )
-        return "I've attached the report."
-
-    return "Failed to retrieve the report."
-```
-
-See the [Python Node documentation](../tech-hub/python_node.md#python_node.add_file_attachment) for the full `add_file_attachment()` API reference.
-
-If a pipeline-produced file cannot be sent as an attachment (for example, it exceeds the size limit or is a denylisted type), the email body will contain an inline download link for that file instead.
+See the [Email channel guide](deploy_email_channel.md) for full setup and configuration details.
 
 [1]: https://core.telegram.org/bots#how-do-i-create-a-bot
 [2]: ../concepts/team/messaging_providers.md

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -11,6 +11,17 @@ To link a channel to your chatbot:
 
 You may need to [Configure a messaging provider][6] before you will be able to select it from the dropdown.
 
+## Jump to a channel
+
+- [Web](#web) — built-in chat interface, no setup required
+- [Telegram](#telegram)
+- [WhatsApp](#whatsapp) — Twilio, Turn.io, or [Meta Cloud API](#meta-cloud-api)
+- [Facebook Messenger](#facebook-messenger)
+- [Slack](#slack)
+- [Email](#email)
+- [SureAdhere](#sureadhere-for-in-app-messaging)
+- [API](#api) — programmatic access, no channel setup required
+
 ## Web
 
 The web channel is OCS's built-in chat interface. It's enabled by default for every chatbot — there's no provider to configure and nothing to link. Embed it on your own site with the [chat widget][chat-widget].
@@ -67,15 +78,15 @@ The Slack channel lets users interact with your chatbot from Slack, either in sp
 
 See the [Slack channel guide](deploy_slack_channel.md) for prerequisites, configuration options, and how chatbot mentions work.
 
-## SureAdhere for In-App messaging
-- Enter the Tenant ID that would have been provided to you when setting up your SureAdhere account.
-- After you submit the form, you will be provided with a webhook URL. Copy this URL and navigate back to your provider's settings to configure it with this URL.
-
 ## Email
 
 The email channel lets users interact with your chatbot by sending and receiving emails, including routing, thread continuity, and file attachments.
 
 See the [Email channel guide](deploy_email_channel.md) for full setup and configuration details.
+
+## SureAdhere for In-App messaging
+- Enter the Tenant ID that would have been provided to you when setting up your SureAdhere account.
+- After you submit the form, you will be provided with a webhook URL. Copy this URL and navigate back to your provider's settings to configure it with this URL.
 
 ## API
 

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -97,7 +97,7 @@ Every chatbot can also be reached programmatically through the OCS [APIs][api], 
 [3]: https://www.twilio.com/docs/WhatsApp/api#configuring-inbound-message-webhooks
 [4]: https://www.twilio.com/docs/conversations/Facebook-messenger#setting-up-the-Facebook-messenger-channel
 [5]: https://core.Telegram.org/bots/features#:~:text=/setjoingroups%20%E2%80%93%20toggle%20whether%20your%20bot%20can%20be%20added%20to%20groups%20or%20not.%20All%20bots%20must%20be%20able%20to%20process%20direct%20messages%2C%20but%20if%20your%20bot%20was%20not%20designed%20to%20work%20in%20groups%2C%20you%20can%20disable%20this.
-[6]: ../tutorials/configure_providers.md
+[6]: ../tutorials/configure_msg_providers.md
 [api]: ../tech-hub/api_access.md
 [meta]: ./whatsapp_meta_cloud_api.md
 [chat-widget]: ../chat_widget/index.md

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -11,8 +11,9 @@ To link a channel to your chatbot:
 
 You may need to [Configure a messaging provider][6] before you will be able to select it from the dropdown.
 
-## Web and API
-The web channel uses the web interface and is enabled by default for all chatbots. Likewise, all chatbots can be accessed via the [APIs][api].
+## Web
+
+The web channel is OCS's built-in chat interface. It's enabled by default for every chatbot — there's no provider to configure and nothing to link. Embed it on your own site with the [chat widget][chat-widget].
 
 ## Telegram
 - Follow [this guide][1] to create a Telegram chatbot.
@@ -66,7 +67,7 @@ The Slack channel lets users interact with your chatbot from Slack, either in sp
 
 See the [Slack channel guide](deploy_slack_channel.md) for prerequisites, configuration options, and how chatbot mentions work.
 
-## SureAdhere
+## SureAdhere for In-App messaging
 - Enter the Tenant ID that would have been provided to you when setting up your SureAdhere account.
 - After you submit the form, you will be provided with a webhook URL. Copy this URL and navigate back to your provider's settings to configure it with this URL.
 
@@ -76,6 +77,10 @@ The email channel lets users interact with your chatbot by sending and receiving
 
 See the [Email channel guide](deploy_email_channel.md) for full setup and configuration details.
 
+## API
+
+Every chatbot can also be reached programmatically through the OCS [APIs][api], which is useful for integrating with third-party systems or building custom front ends.
+
 [1]: https://core.telegram.org/bots#how-do-i-create-a-bot
 [2]: ../concepts/team/messaging_providers.md
 [3]: https://www.twilio.com/docs/WhatsApp/api#configuring-inbound-message-webhooks
@@ -84,3 +89,4 @@ See the [Email channel guide](deploy_email_channel.md) for full setup and config
 [6]: ../tutorials/configure_providers.md
 [api]: ../tech-hub/api_access.md
 [meta]: ./whatsapp_meta_cloud_api.md
+[chat-widget]: ../chat_widget/index.md

--- a/docs/how-to/deploy_to_different_channels.md
+++ b/docs/how-to/deploy_to_different_channels.md
@@ -1,4 +1,4 @@
-# Deploy your chatbot to different platforms
+# Deploy your chatbot to different channels
 
 To link a channel to your chatbot:
 

--- a/docs/tutorials/configure_msg_providers.md
+++ b/docs/tutorials/configure_msg_providers.md
@@ -22,4 +22,4 @@ Messaging providers configured in your [Team](../concepts/team/index.md) setting
 - For WhatsApp Business Platform with Meta, see details [here](../how-to/deploy_to_different_channels.md#meta-cloud-api)
 - For Slack see details [here](../how-to/deploy_to_different_channels.md#slack)
 - For Facebook Messenger see details [here](../how-to/deploy_to_different_channels.md#facebook-messenger)
-- For SureAdhere secure In-App Messaging see details [here](../how-to/deploy_to_different_channels.md#sureadhere)
+- For SureAdhere secure In-App Messaging see details [here](../how-to/deploy_to_different_channels.md#sureadhere-for-in-app-messaging)

--- a/docs/tutorials/configure_msg_providers.md
+++ b/docs/tutorials/configure_msg_providers.md
@@ -22,4 +22,4 @@ Messaging providers configured in your [Team](../concepts/team/index.md) setting
 - For WhatsApp Business Platform with Meta, see details [here](../how-to/deploy_to_different_channels.md#meta-cloud-api)
 - For Slack see details [here](../how-to/deploy_to_different_channels.md#slack)
 - For Facebook Messenger see details [here](../how-to/deploy_to_different_channels.md#facebook-messenger)
-- For SureAdhere secure In-App Messaging see details [here](../how-to/deploy_to_different_channels.md#sureadhere-for-in-app-messaging)
+- For SureAdhere secure In-App Messaging see details [here](../how-to/deploy_to_different_channels.md#sureadhere-for-secure-in-app-messaging)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - how-to/deploy_to_different_channels.md
       - how-to/whatsapp_meta_cloud_api.md
       - how-to/deploy_email_channel.md
+      - how-to/deploy_slack_channel.md
     - UI Helpers:
       - Filter Tables with Natural Language: how-to/nl_filter.md
       - Find Objects: how-to/global_search.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,9 +117,9 @@ nav:
       - Set Up Document Sources: how-to/document_sources.md
     - Channels & Deployment:
       - how-to/deploy_to_different_channels.md
+      - Deploy chatbot to Email: how-to/deploy_email_channel.md
+      - Deploy chatbot to Slack: how-to/deploy_slack_channel.md
       - how-to/whatsapp_meta_cloud_api.md
-      - how-to/deploy_email_channel.md
-      - how-to/deploy_slack_channel.md
     - UI Helpers:
       - Filter Tables with Natural Language: how-to/nl_filter.md
       - Find Objects: how-to/global_search.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
     - Channels & Deployment:
       - how-to/deploy_to_different_channels.md
       - how-to/whatsapp_meta_cloud_api.md
+      - how-to/deploy_email_channel.md
     - UI Helpers:
       - Filter Tables with Natural Language: how-to/nl_filter.md
       - Find Objects: how-to/global_search.md


### PR DESCRIPTION
### Background

Improve readability and findablity of topics:

The **How-to guide** for "deploying chatbots to different platforms" is is a very long page of about 180 lines that also includes a line of length 562
https://docs.openchatstudio.com/how-to/deploy_to_different_channels/

### Details

Reduced from 180 lines to 99 lines

1. New How-to guide pages from sections **Email** and **Slack**
2. Split up "**Web** chat" from "**API** integration for chat" as very different channels so confusing
3. Reduce confusion between "platform", "channel" & "message providers" terminology
4. Consistently use chatbot instead of bot


### Reviewer Notes on terminology

OCS uses "channel" and "platform" interchangeably. You'll mostly see "channel" in these docs, but some parts of the OCS UI use the label "Platform" for the same thing.

From deepwiki - terminology distinction is that "platform" refers to the messaging service type, while "channel" refers to a specific instance/connection to that platform for a particular Chatbot.