### PR TITLE
docs: update annotation export section for pivoted CSV/JSONL format

### DIFF
--- a/docs/concepts/annotations/queues.md
+++ b/docs/concepts/annotations/queues.md
@@ -127,29 +127,48 @@ Aggregates are recomputed after each annotation submission, so you always see up
 
 ## Exporting Results
 
-From the queue detail page (requires queue management permissions), you can export all submitted annotations:
+From the queue detail page (requires queue management permissions), you can export all submitted annotations. Both formats pivot the results so that **each reviewer's answers appear side by side**, making it easy to compare reviewers on the same item.
 
-| Format | Description |
-|--------|-------------|
-| **CSV** | Spreadsheet-friendly, one row per annotation |
-| **JSONL** | One JSON object per line, suitable for programmatic processing |
+| Format | Structure |
+|--------|-----------|
+| **CSV** | Spreadsheet-friendly. One row per (item, schema field), with a column for each reviewer. |
+| **JSONL** | One JSON object per item, suitable for programmatic processing. Each field holds its reviewers' values, keyed by email. |
 
-The export includes the item details, reviewer, and all annotation field values. It also includes flagged items that have no reviewer annotations, so every flagged item appears in the export regardless of review status.
+The export covers every item's submitted annotations. Flagged items are always included, even when they have no annotations, so every flagged item appears regardless of review status.
 
-Each exported record contains the following fields:
+Each exported item carries these shared fields:
 
 | Field | Description |
 |-------|-------------|
-| Item details | Source data for the reviewed item (e.g. message content, session metadata) |
-| Reviewer | The team member who submitted the annotation |
-| Annotation field values | One value per schema field defined on the queue |
-| `session_id` | External UUID of the session linked to the annotation item |
-| `flagged` | Boolean indicating whether the item is flagged |
-| `flagged_reason` | Full list of flag entries recorded on the item |
-| `is_authoritative` | Boolean indicating whether this annotation is the authoritative answer for the item (always `true` on single-reviewer queues; set per-item by an annotation reviewer on multi-reviewer queues) |
+| `item_id` | ID of the annotation item |
+| `item_type` | `session` or `message` |
+| `session_id` | External UUID of the linked session (for message items, the session of the message's chat) |
+| `flagged` | Whether the item is flagged |
+| `flags` | List of flag entries recorded on the item (empty when not flagged) |
+| `authoritative_annotator` | Email of the reviewer whose annotation was picked as authoritative for the item; blank if none has been picked. Auto-set on single-reviewer queues; chosen during resolution on multi-reviewer queues. |
+| `annotated_at` | Timestamp of the most recent annotation on the item |
+
+Each reviewer's answers to the schema fields are attached per format:
+
+- **CSV** adds a `field` column (the schema field name) and one column per reviewer email. Each row is one item/field combination; the reviewer columns hold that reviewer's value, blank where they did not answer.
+- **JSONL** adds a `fields` object shaped `{field: {reviewer_email: value}}`. A field a reviewer did not answer is `null`, and values keep their JSON types (numbers stay numbers).
+
+Example JSONL record:
+
+```json
+{
+  "item_id": 67, "item_type": "session", "session_id": "d99c...",
+  "flagged": false, "flags": [],
+  "authoritative_annotator": "marcus@example.com", "annotated_at": "2026-07-15T13:17:02Z",
+  "fields": {
+    "tone":     {"fatima@example.com": "friendly", "marcus@example.com": "too casual"},
+    "accuracy": {"fatima@example.com": "accurate", "marcus@example.com": "missed grammar"}
+  }
+}
+```
 
 !!! note
-    In CSV exports, `flagged_reason` is JSON-serialized as a string. Use JSONL format if you need to process flag entries programmatically without parsing JSON within a field.
+    In CSV exports, `flags` is JSON-serialized into a single cell. Use JSONL if you need to process flag entries or field values programmatically without parsing JSON from within a column.
 
 ## Managing Assignees
 


### PR DESCRIPTION
### Summary

Updates the "Exporting Results" section of the annotation queue docs to match the pivoted CSV and JSONL export formats.

The annotation queue export now pivots results so each reviewer's answers appear side by side:

- **CSV** (dimagi/open-chat-studio#3832, merged): one row per (item, schema field), one column per reviewer.
- **JSONL** (dimagi/open-chat-studio#3838): one record per item, values nested per field by reviewer email.

The previous docs described the old flat "one row per annotation" shape and the removed `is_authoritative` column. This rewrite:

- Describes both new formats and their structure.
- Replaces `is_authoritative` with `authoritative_annotator`.
- Lists the actual exported fields (`item_id`, `item_type`, `session_id`, `flagged`, `flags`, `authoritative_annotator`, `annotated_at`).
- Corrects the column name `flagged_reason` -> `flags`.
- Adds an example JSONL record.

Strict build (`uv run zensical build --clean --strict`) passes with no issues.

Closes #571.

### Related
- Code PR: dimagi/open-chat-studio#3838
- CSV pivot (merged, previously undocumented): dimagi/open-chat-studio#3832
