### PR TITLE
Reverted: debuging code & using claude sonnet 5 for claude-dependabot.yml

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -71,14 +71,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "dependabot[bot]"
-          # TEMPORARY debugging aids for the uv-ecosystem timeout (~183s, is_error:true,
-          # num_turns:1, total_cost_usd:0 on every Python dependency PR). show_full_output
-          # surfaces the real SDK/API error instead of the redacted summary; pinning a
-          # non-beta model rules out the default claude-opus-4-8[1m] (1M-context beta)
-          # resolution as the cause. Revert both once the root cause is confirmed/fixed.
-          show_full_output: true
           claude_args: |
-            --model claude-sonnet-5 --allowedTools "Bash(uv:*),Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Edit,WebFetch,WebSearch"
+            --allowedTools "Bash(uv:*),Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Edit,WebFetch,WebSearch"
           prompt: |
             You are reviewing PR #${{ steps.pr.outputs.pr_number }}.
 


### PR DESCRIPTION
### Background

The dependabot Claude PR review was failing. Details in: https://github.com/dimagi/open-chat-studio-docs/issues/601 with error message: 
is_error:true with the message: "Claude result reported subtype success with is_error:true (run did not complete successfully)".

**To address this issue,** added debugging code and pinned workflow to use claude sonnet 5 in PR https://github.com/dimagi/open-chat-studio-docs/pull/602, 

### Details to why regression of this fix/debugging info

This workflow `claude-dependabot.yml` is not failing anymore and this was  confirmed by Simon in comment: https://github.com/dimagi/open-chat-studio-docs/issues/601#issuecomment-5117954001 - "It failed initially because of an expired API key which I fixed."

#### Details of what done

1. Reverted debugging code that was added in PR  https://github.com/dimagi/open-chat-studio-docs/pull/602, 
2. And removed Sonnet 5 so it will use default AI model
