### PR TITLE
Accuracy of "Reset Sessions" & "Session Status" 

### DIFF
--- a/docs/concepts/evaluations/evaluators.md
+++ b/docs/concepts/evaluations/evaluators.md
@@ -77,7 +77,7 @@ The system automatically validates the LLM's output against the specified types 
 |-------------|------|-------------|
 | expected_helpfulness | integer | The helpfulness, on a scale of 1-5, of the expected assistant message |
 | actual_helpfulness | integer | The helpfulness, on a scale of 1-5, of the actual assistant message |
-| user_sentiment | choice | The sentiment of the participant message (options: positive, neutral, negative) |
+| user_sentiment | choice | The sentiment of the user message (options: positive, neutral, negative) |
 | confidence_score | float | Confidence in the evaluation, from 0.0 to 1.0 |
 
 See [Tag Rules](./tag_rules.md) to automatically tag sessions or messages based on these output values.

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -37,7 +37,7 @@ Static events are predefined triggers that occur based on specific actions or co
 
 Each event is associated with one action. The available actions are:
 
-- **End the conversation**: Ends the conversation with the participant. See [How to reset sessions](../how-to/reset_sessions.md) and [Session Status](session_status.md).
+- **End the conversation**: Ends the conversation with the participant. See [Ending session with events](../tech-hub/ending_sessions.md#events-with-an-end-the-conversation-action) for more details
 - **Prompt the bot to message the user**: Prompts the chatbot to message the participants.
 - **Trigger a schedule**: This will create a once off or recurring schedule. Each time the schedule is triggered, the chatbot will be prompted to message the participant.
 - **Start a pipeline**: This will run the given pipeline when the event triggers. The input to the pipeline can be configured.

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -37,7 +37,7 @@ Static events are predefined triggers that occur based on specific actions or co
 
 Each event is associated with one action. The available actions are:
 
-- **End the conversation**: Ends the conversation with the participant. See [Ending session with events](../tech-hub/ending_sessions.md#events-with-an-end-the-conversation-action) for more details
+- **End the conversation**: Ends the conversation with the participant. See [Ending session with events](../tech-hub/ending_sessions.md#events-with-an-end-the-conversation-action) for more details.
 - **Prompt the bot to message the user**: Prompts the chatbot to message the participants.
 - **Trigger a schedule**: This will create a once off or recurring schedule. Each time the schedule is triggered, the chatbot will be prompted to message the participant.
 - **Start a pipeline**: This will run the given pipeline when the event triggers. The input to the pipeline can be configured.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -60,6 +60,9 @@ For step-by-step instructions on completing specific tasks, see the [How-to guid
 [Node](./pipelines/nodes.md)
 : A single processing step in a pipeline. Each node performs one task, such as calling an LLM, running custom code, or routing the conversation based on its content.
 
+[Participant](participant_data.md)
+: The person chatting with a deployed chatbot through any channel — as distinct from an OCS user, who builds and manages chatbots.
+
 [Participant Data](participant_data.md)
 : Custom information stored against each participant — the person chatting with a deployed chatbot — that persists across chatbot sessions. Use it to remember preferences, track progress, or personalize chatbot responses.
 

--- a/docs/concepts/session_status.md
+++ b/docs/concepts/session_status.md
@@ -68,7 +68,7 @@ A session moves to `PENDING_REVIEW` whenever the conversation ends. This can hap
 
 **Participant actions:**
 
-- Clicks **End chat** on the web chat page.
+- Clicks **End chat and give feedback** on the OCS hosted web chat page.
 - Sends `/reset` on a messaging channel (also surfaced as "Restart chat" on Telegram).
 
 **Chatbot-driven actions** — the chatbot itself ends the session, using one of three methods described in [Ending sessions from a chatbot](../tech-hub/ending_sessions.md):
@@ -79,8 +79,8 @@ A session moves to `PENDING_REVIEW` whenever the conversation ends. This can hap
 
 **Team member actions:**
 
-- Clicks **End Session** on a Chatbot Review session detail page in the OCS admin.
-- Clicks **New Session** on a messaging channel session, which ends the old session as a side effect.
+- Clicks **End Session** button on a Chatbot Review session detail page in the OCS admin.
+- Clicks **New Session** button on a messaging channel session (ie non-web channels), which ends the old session as a side effect.
 
 **API:**
 
@@ -100,7 +100,7 @@ Regardless of what ends a session — participant, chatbot, admin, API caller, o
 
 | Trigger type | Fires when |
 |--------------|------------|
-| The Conversation is Ended by the Participant | The participant ends the chat (web "End chat" or `/reset`). |
+| The Conversation is Ended by the Participant | The participant ends the chat (web "End chat and give feedback" or `/reset`). |
 | The Conversation is Ended by the Bot | The chatbot ends the chat (End Session tool or `end_session()`). |
 | The Conversation is Ended via the API | An API caller ends the session. |
 | The Conversation is Ended by an Event | An "End the conversation" event action ended the session. |

--- a/docs/concepts/session_status.md
+++ b/docs/concepts/session_status.md
@@ -71,11 +71,11 @@ A session moves to `PENDING_REVIEW` whenever the conversation ends. This can hap
 - Clicks **End chat** on the web chat page.
 - Sends `/reset` on a messaging channel (also surfaced as "Restart chat" on Telegram).
 
-**Chatbot-driven actions** (see [Ending sessions from a chatbot](../tech-hub/ending_sessions.md)):
+**Chatbot-driven actions** — the chatbot itself ends the session, using one of three methods described in [Ending sessions from a chatbot](../tech-hub/ending_sessions.md):
 
-- An LLM tool call ends the session.
-- A Python pipeline node calls `end_session()`.
-- An [event](events.md) with an **End the conversation** action fires.
+- The LLM calls the [End Session tool](../tech-hub/ending_sessions.md#the-end-session-tool).
+- A Python pipeline node calls [`end_session()`](../tech-hub/ending_sessions.md#the-end_session-helper-in-a-python-node).
+- An [event](events.md) fires with an [End the conversation action](../tech-hub/ending_sessions.md#events-with-an-end-the-conversation-action).
 
 **Team member actions:**
 
@@ -93,12 +93,6 @@ There is exactly one path to `COMPLETE`: the participant is redirected to the re
 ### UNKNOWN
 
 No deliberate action places a session in `UNKNOWN`. It exists as a defensive fallback. If you see sessions landing here, this indicates an unexpected state — worth investigating rather than ignoring.
-
-## Ending sessions from a chatbot programatically
-
-There are three ways to end a session programmatically from within your chatbot: an LLM node can be given the **End Session** tool, a Python pipeline node can call the `end_session()` helper, or an [event](events.md) can be configured with an **End the conversation** action. All three behave identically once triggered — the session moves to `PENDING_REVIEW`, the end time is recorded, and any configured conversation-end events fire.
-
-For configuration details on each option, see [Ending sessions from a chatbot](../tech-hub/ending_sessions.md).
 
 ## Observing how a session ended
 

--- a/docs/concepts/session_status.md
+++ b/docs/concepts/session_status.md
@@ -68,7 +68,7 @@ A session moves to `PENDING_REVIEW` whenever the conversation ends. This can hap
 
 **Participant actions:**
 
-- Clicks **End chat and give feedback** on the OCS hosted web chat page.
+- Clicks **End chat and give feedback** on the web chat page.
 - Sends `/reset` on a messaging channel (also surfaced as "Restart chat" on Telegram).
 
 **Chatbot-driven actions** — the chatbot itself ends the session, using one of three methods described in [Ending sessions from a chatbot](../tech-hub/ending_sessions.md):

--- a/docs/concepts/session_status.md
+++ b/docs/concepts/session_status.md
@@ -77,7 +77,7 @@ A session moves to `PENDING_REVIEW` whenever the conversation ends. This can hap
 - A Python pipeline node calls [`end_session()`](../tech-hub/ending_sessions.md#the-end_session-helper-in-a-python-node).
 - An [event](events.md) fires with an [End the conversation action](../tech-hub/ending_sessions.md#events-with-an-end-the-conversation-action).
 
-**Team member actions:**
+**OCS User actions:**
 
 - Clicks **End Session** button on a Chatbot Review session detail page in the OCS admin.
 - Clicks **New Session** button on a messaging channel session (ie non-web channels), which ends the old session as a side effect.
@@ -104,7 +104,7 @@ Regardless of what ends a session — participant, chatbot, admin, API caller, o
 | The Conversation is Ended by the Bot | The chatbot ends the chat (End Session tool or `end_session()`). |
 | The Conversation is Ended via the API | An API caller ends the session. |
 | The Conversation is Ended by an Event | An "End the conversation" event action ended the session. |
-| The Conversation is Manually Ended by an Admin | A team member ended the session via the OCS admin. |
+| The Conversation is Manually Ended by a User | A team member ended the session via the OCS admin. |
 
 The generic **Conversation End** trigger fires for all of the above. Use it when you want to take the same action regardless of how the session ended. See [Events](events.md) for more detail.
 

--- a/docs/concepts/session_status.md
+++ b/docs/concepts/session_status.md
@@ -71,7 +71,7 @@ A session moves to `PENDING_REVIEW` whenever the conversation ends. This can hap
 - Clicks **End chat** on the web chat page.
 - Sends `/reset` on a messaging channel (also surfaced as "Restart chat" on Telegram).
 
-**Chatbot-driven actions** (see [Ending sessions from a chatbot](#ending-sessions-from-a-chatbot) below):
+**Chatbot-driven actions** (see [Ending sessions from a chatbot](../tech-hub/ending_sessions.md)):
 
 - An LLM tool call ends the session.
 - A Python pipeline node calls `end_session()`.
@@ -79,8 +79,8 @@ A session moves to `PENDING_REVIEW` whenever the conversation ends. This can hap
 
 **Team member actions:**
 
-- Clicks **End session** on a session detail page in the OCS admin.
-- Clicks **New session** on a messaging channel session, which ends the old session as a side effect.
+- Clicks **End Session** on a Chatbot Review session detail page in the OCS admin.
+- Clicks **New Session** on a messaging channel session, which ends the old session as a side effect.
 
 **API:**
 
@@ -94,50 +94,11 @@ There is exactly one path to `COMPLETE`: the participant is redirected to the re
 
 No deliberate action places a session in `UNKNOWN`. It exists as a defensive fallback. If you see sessions landing here, this indicates an unexpected state — worth investigating rather than ignoring.
 
-## Ending sessions from a chatbot
+## Ending sessions from a chatbot programatically
 
-You have three ways to end a session programmatically from within your chatbot. All three behave identically once triggered — the session moves to `PENDING_REVIEW`, the end time is recorded, and any configured conversation-end [events](events.md) fire.
+There are three ways to end a session programmatically from within your chatbot: an LLM node can be given the **End Session** tool, a Python pipeline node can call the `end_session()` helper, or an [event](events.md) can be configured with an **End the conversation** action. All three behave identically once triggered — the session moves to `PENDING_REVIEW`, the end time is recorded, and any configured conversation-end events fire.
 
-### The End Session tool
-
-Add the **End Session** tool to your LLM node's tool list. The LLM can then choose to end the chat when it judges the conversation is over.
-
-The tool description presented to the LLM is: *"End the current chat session. This will mark the session as completed. New messages will result in a new session being created."*
-
-In that description, "completed" means the conversation is finished — the session moves to `PENDING_REVIEW`. It does not move directly to the `COMPLETE` status, which only happens once the participant submits the post-conversation review.
-
-The session ends after the chatbot's reply is delivered to the participant.
-
-For full configuration details, see the [End Session tool reference](../tech-hub/tools.md#end-session).
-
-!!! warning "Not available for Assistant-style chatbots"
-    The End Session tool cannot be used with Assistant-style chatbots.
-
-Use this approach when the decision to end the conversation belongs to the LLM — for example, "end the session once the user confirms they are done".
-
-### The `end_session()` helper in a Python node
-
-Inside a [Python pipeline node](../tech-hub/python_node.md), the runtime exposes an `end_session()` helper:
-
-```python
-def main(input, **kwargs):
-    if should_finish(input):
-        end_session()
-    return "Goodbye!"
-```
-
-Calling `end_session()` ends the session after the pipeline finishes and the response is delivered. The returned message is still sent to the participant first.
-
-Use this approach when the decision to end the conversation belongs to your custom logic — for example, a state-machine progression or a specific sentinel input from the participant.
-
-### Events with an "End the conversation" action
-
-Configure an [event](events.md) whose action is **End the conversation**:
-
-- **Static triggers** — fire on a lifecycle event such as a new chatbot message, a participant joining, or a conversation starting. Useful when you want the session to end as soon as the chatbot sends a specific goodbye message.
-- **Timeout triggers** — fire after a period of inactivity. Useful for "end the session if the participant is silent for 30 minutes".
-
-Use this approach when the decision to end the conversation should be driven by lifecycle conditions outside the pipeline itself.
+For configuration details on each option, see [Ending sessions from a chatbot](../tech-hub/ending_sessions.md).
 
 ## Observing how a session ended
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -18,6 +18,7 @@ Each session is independent and isolated, meaning:
 - When a participant interacts with a chatbot, the chatbot receives the session's history to maintain context.
 - **Multi-Session Channels**: Channels such as **Web**, **API**, and **Slack** allow multiple active sessions per participant, enabling parallel conversations.
 - **Single-Session Channels**: Platforms like **WhatsApp**, **Telegram**, and **SureAdhere** support only one active session per participant at a time.
+- **Status**: Every session has a status that tracks where the participant is in their chat journey. See [Session Status](session_status.md).
 
 ## History Management
 
@@ -43,6 +44,6 @@ On the **Web** channel, participants can have **anonymous sessions**, where:
 
 For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current session continues until it is explicitly ended.
 
-However, sessions can be reset either [manually](../how-to/reset_sessions.md#manual-reset-of-a-session) by the participant or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically).
+Sessions can be reset either [manually](../how-to/reset_sessions.md#manual-reset-of-a-session) by the participant or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically).
 
 For task-focused setup instructions, see [How to reset sessions](../how-to/reset_sessions.md).

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -12,7 +12,7 @@ A session is uniquely defined by:
 - **Channel**: The platform through which the chat occurs (e.g., WhatsApp, Telegram, Web, Slack). See [channels](channels.md).
 - **Chatbot**: The specific chatbot handling the conversation.
 
-Each session is independent, meaning:
+Each session is independent and isolated, meaning:
 
 - The session's data is bound to that session only and is not shared with other sessions.
 - When a participant interacts with a chatbot, the chatbot receives the session's history to maintain context.
@@ -44,12 +44,5 @@ On the **Web** channel, participants can have **anonymous sessions**, where:
 For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current session continues until it is explicitly ended.
 
 However, sessions can be reset either [manually](../how-to/reset_sessions.md#manual-reset-of-a-session) by the participant or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically).
-
-When a session is reset:
-
-- The current session is marked as completed.
-- A new session is started with a fresh history.
-
-This means that, aside from participant data, the chatbot loses all information about the previous conversation — including the fact that it even took place.
 
 For task-focused setup instructions, see [How to reset sessions](../how-to/reset_sessions.md).

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -46,4 +46,4 @@ For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current 
 
 Sessions can be reset either [manually](../how-to/reset_sessions.md#manual-reset-of-a-session) by the participant or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically).
 
-For task-focused setup instructions, see [How to reset sessions](../how-to/reset_sessions.md).
+For task-focused details, see [How to reset sessions](../how-to/reset_sessions.md).

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -8,7 +8,7 @@ Chat sessions in Open Chat Studio define the scope of conversations between a pa
 
 A session is uniquely defined by:
 
-- **Participant**: The individual engaging with the chatbot. See [Participant Data](participant_data.md).
+- **Participant**: The individual engaging with the chatbot.
 - **Channel**: The platform through which the chat occurs (e.g., WhatsApp, Telegram, Web, Slack). See [channels](channels.md).
 - **Chatbot**: The specific chatbot handling the conversation.
 
@@ -43,7 +43,7 @@ On the **Web** channel, participants can have **anonymous sessions**, where:
 
 For **Single-Session Channels** like **WhatsApp** and **Telegram**, the current session continues until it is explicitly ended.
 
-However, sessions can be reset either [manually](../how-to/reset_sessions.md#user-initiated-manual-reset-of-a-session) by the participant or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically).
+However, sessions can be reset either [manually](../how-to/reset_sessions.md#manual-reset-of-a-session) by the participant or [automatically](../how-to/reset_sessions.md#reset-sessions-automatically).
 
 When a session is reset:
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -12,13 +12,14 @@ A session is uniquely defined by:
 - **Channel**: The platform through which the chat occurs (e.g., WhatsApp, Telegram, Web, Slack). See [channels](channels.md).
 - **Chatbot**: The specific chatbot handling the conversation.
 
-Each session is independent and isolated, meaning:
+Each session is independent, meaning:
 
 - The session's data is bound to that session only and is not shared with other sessions.
 - When a participant interacts with a chatbot, the chatbot receives the session's history to maintain context.
 - **Multi-Session Channels**: Channels such as **Web**, **API**, and **Slack** allow multiple active sessions per participant, enabling parallel conversations.
 - **Single-Session Channels**: Platforms like **WhatsApp**, **Telegram**, and **SureAdhere** support only one active session per participant at a time.
-- **Status**: Every session has a status that tracks where the participant is in their chat journey. See [Session Status](session_status.md).
+
+Every session has a status that tracks where the participant is in their chat journey. See [Session Status](session_status.md).
 
 ## History Management
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -37,7 +37,7 @@ This command is available on all channels except **Web Chat Widget** and **Slack
 3. Confirm that you want to start a new chat.
 4. Continue chatting to start a fresh session.
 
-### OCS User reset manually from the OCS Admin UI
+### OCS user reset manually from the OCS Admin UI
 
 When viewing the session detail on the Chatbot Review page, an OCS user with permission to manage sessions has two options:
 
@@ -46,7 +46,7 @@ When viewing the session detail on the Chatbot Review page, an OCS user with per
 
 ## Reset sessions automatically
 
-For details on how to end sessions from a chatbot see [Session Status](../concepts/session_status.md#ending-sessions-from-a-chatbot)
+For details on how to end sessions from a chatbot see [Ending Sessions from a Chatbot](../tech-hub/ending_sessions.md)
 
 ### Reset automatically via API
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -28,12 +28,12 @@ When a session is reset:
 2. Send `/reset` (case-insensitive) as a text command
 3. Continue chatting to start a fresh session.
 
-This command is available on all channels except **Web Chat Widget** and **Slack**.
+This command is available on all channels except **Web** and **Slack**.
 
-### Participant reset manually from the Web Chat Widget
+### Participant reset manually from the Web Chat
 
-1. As a participant, view the chat widget on the web chat interface.
-2. Click the "New Chat" button.
+1. As a participant viewing the OCS's own hosted web chat page
+2. Click the "End chat and give feedback" button.
 3. Confirm that you want to start a new chat.
 4. Continue chatting to start a fresh session.
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -4,13 +4,12 @@ title: How to reset sessions
 
 # How to reset sessions
 
-Use this guide to end a current [session](../concepts/sessions.md) and start a new one. Resets can be done [manually](#manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
+Use this guide to end a current [session](../concepts/sessions.md) and start a new one.
 
 ## Before you begin
 
 - Confirm which [channel](../concepts/channels.md) your chatbot uses.
-- For **Web Chat Widget** and **Slack**, use the session reset button in the UI.
-- For messaging channels (such as WhatsApp and Telegram), use `/reset` or an automatic method.
+- Resets can be done [manually](#manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
 
 !!! note
 
@@ -32,8 +31,7 @@ This allows participants to customize how the transition between sessions occurs
 
 1. As a participant, view the chat widget on the web chat interface.
 2. Click the "End chat" button.
-3. Choose whether to trigger [end conversation events](../concepts/events.md) or skip them
-4. Enter a chat message for the new session.
+3. Enter a chat message for the new session.
 
 ### OCS User reset manually from the OCS Admin UI
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -4,16 +4,21 @@ title: How to reset sessions
 
 # How to reset sessions
 
-This guide explains how to end a current [session](../concepts/sessions.md) and start a new one.
+This guide explains how to end a current chatbot [session](../concepts/sessions.md) and start a new one.
 
-## Before you begin
+When a session is reset:
 
-- Confirm which [channel](../concepts/channels.md) your chatbot uses — this determines which reset options are available to you.
-- Resets can be triggered [manually](#manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
+- The current session is marked as completed.
+- A new session is started with a fresh history.
 
 !!! note
 
-    Resetting a session clears the conversation history — the bot will have no memory of previous exchanges. Participant data is not removed.
+    Resetting a session clears the conversation history — the chatbot will have no memory of previous exchanges. [participant data](../concepts/participant_data.md) is not removed.
+
+## Before you begin
+
+- Confirm which [channel](../concepts/channels.md) your chatbot uses — this determines which reset options are available.
+- Resets can be triggered [manually](#manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
 
 ## Manual reset of a session
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -4,7 +4,7 @@ title: How to reset sessions
 
 # How to reset sessions
 
-Use this guide to end a current [session](../concepts/sessions.md) and start a new one. Resets can be done [manually](#user-initiated-manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
+Use this guide to end a current [session](../concepts/sessions.md) and start a new one. Resets can be done [manually](#manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
 
 ## Before you begin
 
@@ -16,9 +16,9 @@ Use this guide to end a current [session](../concepts/sessions.md) and start a n
 
     Resetting a session clears the conversation history — the bot will have no memory of previous exchanges. Participant data is not removed.
 
-## User-Initiated manual reset of a session
+## Manual reset of a session
 
-### Reset manually from chat channel
+### Participant reset manually from chat channel
 
 1. As a participant, view the conversation in the chatbot channel
 2. Send `/reset` (case-insensitive) as a text command
@@ -26,7 +26,7 @@ Use this guide to end a current [session](../concepts/sessions.md) and start a n
 
 This command is available on all channels except **Web Chat Widget** and **Slack**.
 
-### Reset manually from the web UI
+### Participant reset manually from the Web Chat Widget
 
 This allows participants to customize how the transition between sessions occurs.
 
@@ -35,12 +35,12 @@ This allows participants to customize how the transition between sessions occurs
 3. Choose whether to trigger [end conversation events](../concepts/events.md) or skip them
 4. Enter a chat message for the new session.
 
-If your chatbot has been configured with a seed message, this is pre-filled and then can be edited by the participant.
+### OCS User reset manually from the OCS Admin UI
 
-### Reset manually from the OCS Admin UI
+When viewing the session detail on the Chatbot Review page, an OCS user with permission to manage sessions has two options:
 
-When viewing the session detail, the "End Session" button ends the current session.
-- For more on ending sessions see [Session Status](../concepts/session_status.md#pending_review)
+- **End Session** — ends the current session. This does not start a new one.
+- **New Session** — ends the current session and starts a new one. This option is only available for non-Web channels.
 
 ## Reset sessions automatically
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -4,12 +4,12 @@ title: How to reset sessions
 
 # How to reset sessions
 
-Use this guide to end a current [session](../concepts/sessions.md) and start a new one.
+This guide explains how to end a current [session](../concepts/sessions.md) and start a new one.
 
 ## Before you begin
 
-- Confirm which [channel](../concepts/channels.md) your chatbot uses.
-- Resets can be done [manually](#manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
+- Confirm which [channel](../concepts/channels.md) your chatbot uses — this determines which reset options are available to you.
+- Resets can be triggered [manually](#manual-reset-of-a-session) or [automatically](#reset-sessions-automatically).
 
 !!! note
 
@@ -27,11 +27,10 @@ This command is available on all channels except **Web Chat Widget** and **Slack
 
 ### Participant reset manually from the Web Chat Widget
 
-This allows participants to customize how the transition between sessions occurs.
-
 1. As a participant, view the chat widget on the web chat interface.
-2. Click the "End chat" button.
-3. Enter a chat message for the new session.
+2. Click the "New Chat" button.
+3. Confirm that you want to start a new chat.
+4. Continue chatting to start a fresh session.
 
 ### OCS User reset manually from the OCS Admin UI
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -22,7 +22,7 @@ When a session is reset:
 
 ## Manual reset of a session
 
-### Participant reset manually from chat channel
+### Participant reset manually from chatbot channel
 
 1. As a participant, view the conversation in the chatbot channel
 2. Send `/reset` (case-insensitive) as a text command
@@ -34,10 +34,10 @@ This command is available on all channels except **Web** and **Slack**.
 
 1. As a participant viewing the OCS's own hosted web chat page
 2. Click the "End chat and give feedback" button.
-3. Confirm that you want to start a new chat.
+3. Confirm that you want to end the chat.
 4. Continue chatting to start a fresh session.
 
-### OCS user reset manually from the OCS Admin UI
+### User reset manually from the OCS Admin UI
 
 When viewing the session detail on the Chatbot Review page, an OCS user with permission to manage sessions has two options:
 

--- a/docs/how-to/reset_sessions.md
+++ b/docs/how-to/reset_sessions.md
@@ -13,7 +13,7 @@ When a session is reset:
 
 !!! note
 
-    Resetting a session clears the conversation history — the chatbot will have no memory of previous exchanges. [participant data](../concepts/participant_data.md) is not removed.
+    Resetting a session clears the conversation history — the chatbot will have no memory of previous exchanges. [Participant data](../concepts/participant_data.md) is not removed.
 
 ## Before you begin
 
@@ -22,17 +22,17 @@ When a session is reset:
 
 ## Manual reset of a session
 
-### Participant reset manually from chatbot channel
+### Participant reset manually from messaging channel
 
-1. As a participant, view the conversation in the chatbot channel
-2. Send `/reset` (case-insensitive) as a text command
+1. As a participant, view the conversation in the messaging channel.
+2. Send `/reset` (case-insensitive) as a text command.
 3. Continue chatting to start a fresh session.
 
 This command is available on all channels except **Web** and **Slack**.
 
-### Participant reset manually from the Web Chat
+### Participant reset manually from the web chat page
 
-1. As a participant viewing the OCS's own hosted web chat page
+1. As a participant, view the OCS's web chat page.
 2. Click the "End chat and give feedback" button.
 3. Confirm that you want to end the chat.
 4. Continue chatting to start a fresh session.

--- a/docs/tech-hub/ending_sessions.md
+++ b/docs/tech-hub/ending_sessions.md
@@ -1,0 +1,46 @@
+# Ending Sessions from a Chatbot
+
+This page is a technical reference for the ways a chatbot can end a [chat session](../concepts/sessions.md) programmatically. For how this fits into the overall session lifecycle, see [Session Status](../concepts/session_status.md).
+
+You have three ways to end a session programmatically from within your chatbot. All three behave identically once triggered — the session moves to `PENDING_REVIEW`, the end time is recorded, and any configured conversation-end [events](../concepts/events.md) fire.
+
+## The End Session tool
+
+Add the **End Session** tool to your LLM node's tool list. The LLM can then choose to end the chat when it judges the conversation is over.
+
+The tool description presented to the LLM is: *"End the current chat session. This will mark the session as completed. New messages will result in a new session being created."*
+
+In that description, "completed" means the conversation is finished — the session moves to `PENDING_REVIEW`. It does not move directly to the `COMPLETE` status, which only happens once the participant submits the post-conversation review.
+
+The session ends after the chatbot's reply is delivered to the participant.
+
+For full configuration details, see the [End Session tool reference](tools.md#end-session).
+
+!!! warning "Not available for Assistant-style chatbots"
+    The End Session tool cannot be used with Assistant-style chatbots.
+
+Use this approach when the decision to end the conversation belongs to the LLM — for example, "end the session once the user confirms they are done".
+
+## The `end_session()` helper in a Python node
+
+Inside a [Python pipeline node](python_node.md), the runtime exposes an `end_session()` helper:
+
+```python
+def main(input, **kwargs):
+    if should_finish(input):
+        end_session()
+    return "Goodbye!"
+```
+
+Calling `end_session()` ends the session after the pipeline finishes and the response is delivered. The returned message is still sent to the participant first.
+
+Use this approach when the decision to end the conversation belongs to your custom logic — for example, a state-machine progression or a specific sentinel input from the participant.
+
+## Events with an "End the conversation" action
+
+Configure an [event](../concepts/events.md) whose action is **End the conversation**:
+
+- **Static triggers** — fire on a lifecycle event such as a new chatbot message, a participant joining, or a conversation starting. Useful when you want the session to end as soon as the chatbot sends a specific goodbye message.
+- **Timeout triggers** — fire after a period of inactivity. Useful for "end the session if the participant is silent for 30 minutes".
+
+Use this approach when the decision to end the conversation should be driven by lifecycle conditions outside the pipeline itself.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,6 +186,7 @@ nav:
     - tech-hub/index.md
     - Local Index Optimization: tech-hub/local-index-optimization.md
     - Tools Reference: tech-hub/tools.md
+    - Ending Sessions from a Chatbot: tech-hub/ending_sessions.md
     - Python Node: tech-hub/python_node.md
     - Render a Template and Send an Email Nodes: tech-hub/template_and_email_nodes.md
     - Call External APIs:


### PR DESCRIPTION
### Background

Review comments highlighted issues about accurate button names, clarity & duplication from this PR https://github.com/dimagi/open-chat-studio-docs/pull/646 for consistent terminology for "users" and "participants"

### Overview of Improvements
- Accuracy, especially of UI button names
- Remove duplication, especially when are contradictions
- Reduce long pages
- Content in appropriate page type


### Improvements needed highlighted in PR 646
- Rewrote `reset_sessions.md`  for accuracy (checked code), readability, duplication and terminology
- Added new "participant" term on concepts page 
- Revert an incorrect fix on `Evaluators.md` as per Review on PR - docs/concepts/evaluations/evaluators.md:80 for terminology

### More improvements after Claude review for this PR

**Carved out Tech Hub page for Ending Sessions**

1. New page: `docs/tech-hub/ending_sessions.md` 
2. Moved: The entire ## Ending sessions from a chatbot section from `session_status.md` .  Content is factually unchanged; only relative links were adjusted 

**The new button names contradict in session_status.md vs reset_sessions.md**

"End chat_" → "_End chat and give feedback"  in `reset_sessions.md` with link from `session_status.md` places (matches the actual template label; "End chat" is only the modal's confirm button).


### Questions for Reviewer ?

As I understand  OCS own hosted web chat page is **different** to a chat widget embedded in a web page. They differ in **how the UI** is served and **how the session** is started/managed
So check these changes for accuracy!!