### PR TITLE
[DevOps] supply-chain security / CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "tuesday"
     cooldown:
       default-days: 7
@@ -20,7 +20,7 @@ updates:
     directory: "/"
     open-pull-requests-limit: 5
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "tuesday"
     # Only touch pyproject.toml when the new version falls outside the declared
     # constraint (e.g. pinned or capped deps). Otherwise update uv.lock alone,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     schedule:
       interval: "monthly"
       day: "tuesday"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
+# A note on `cooldown`: it delays *version* update PRs so a freshly published
+# release has time to be found malicious and unpublished before we adopt it.
+# It deliberately does not apply to Dependabot *security* updates, so advisory
+# fixes still land immediately.
+# uv has a client-side equivalent (`tool.uv.exclude-newer` in pyproject.toml)
+# that we don't currently set; actions and pre-commit have no such lever,
+# so cooldown is the only guard there.
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "tuesday"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -12,8 +22,20 @@ updates:
     schedule:
       interval: "monthly"
       day: "tuesday"
+    # Only touch pyproject.toml when the new version falls outside the declared
+    # constraint (e.g. pinned or capped deps). Otherwise update uv.lock alone,
+    # so floors stay at the version we actually need rather than ratcheting to
+    # the latest release and needlessly narrowing the resolver's options.
+    versioning-strategy: "increase-if-necessary"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,20 @@ on:
   push:
     branches:
       - main
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+
+# Restrict default permissions — job overrides as needed
+permissions: {}
+
 jobs:
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/configure-pages@v6
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
       - uses: actions/configure-pages@v6
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v7
-        with:
-          python-version: 3.x
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - run: uv sync
+      - run: uv sync --locked
       - run: uv pip install .
       - run: uv run zensical build --clean --strict
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - run: uv sync --locked
-      - run: uv pip install .
       - run: uv run zensical build --clean --strict
 
       - uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -21,6 +21,9 @@ on:
         required: true
         type: string
 
+# Restrict default permissions — job overrides as needed
+permissions: {}
+
 jobs:
   dependabot-review:
     # Only run on Dependabot PRs, or manual dispatch for testing

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -51,11 +51,6 @@ jobs:
           ref: ${{ steps.pr.outputs.ref }}
           fetch-depth: 1
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Restrict default permissions — job overrides as needed
+permissions: {}
+
 jobs:
   review:
     if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'automated') }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Restrict default permissions — job overrides as needed
+permissions: {}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,11 +38,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: 3.x
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,7 +47,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
         description: 'Name for the release'
         required: false
 
+# Restrict default permissions — job overrides as needed
+permissions: {}
+
 jobs:
   create-weekly-release:
     permissions:

--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -20,11 +20,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -31,7 +31,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Fetch OpenAPI schema directory
         env:

--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -7,13 +7,17 @@ on:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC
   workflow_dispatch:  # Allow manual trigger
 
-permissions:
-  contents: write
-  pull-requests: write
+# Restrict default permissions — job overrides as needed
+permissions: {}
 
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,11 +18,8 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
+# Restrict default permissions — job overrides as needed
+permissions: {}
 
 # Prevent concurrent runs for the same PR to avoid conflicts
 concurrency:
@@ -32,6 +29,13 @@ concurrency:
 jobs:
   update-changelog-and-docs:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+
     env:
       WIDGET_PATH_PREFIX: "components/"
       WIDGET_CHANGELOG: "docs/chat_widget/changelog.md"

--- a/.github/workflows/update-confluence.yml
+++ b/.github/workflows/update-confluence.yml
@@ -22,10 +22,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: pip install requests markdown
+        run: uv sync --locked
 
       - name: Resolve release info from manual input
         if: github.event_name == 'workflow_dispatch'
@@ -63,4 +66,4 @@ jobs:
           CONFLUENCE_EMAIL: ${{ secrets.CONFLUENCE_EMAIL }}
           CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
           CONFLUENCE_PAGE_ID: "3032678414"
-        run: python scripts/update_confluence_release.py
+        run: uv run python scripts/update_confluence_release.py

--- a/.github/workflows/update-confluence.yml
+++ b/.github/workflows/update-confluence.yml
@@ -11,9 +11,15 @@ on:
         description: "Release tag to sync (e.g. v2026.04.13). Must be an existing release."
         required: true
 
+# Restrict default permissions — job overrides as needed
+permissions: {}
+
 jobs:
   update-confluence:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Check out repository

--- a/.github/workflows/update-confluence.yml
+++ b/.github/workflows/update-confluence.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install dependencies
-        run: uv sync --locked
-
       - name: Resolve release info from manual input
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -67,4 +64,4 @@ jobs:
           CONFLUENCE_EMAIL: ${{ secrets.CONFLUENCE_EMAIL }}
           CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
           CONFLUENCE_PAGE_ID: "3032678414"
-        run: uv run python scripts/update_confluence_release.py
+        run: uv run --locked --only-group confluence python scripts/update_confluence_release.py

--- a/.github/workflows/update-confluence.yml
+++ b/.github/workflows/update-confluence.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "mkdocs-redirects>=1.2.3",
     "mkdocstrings[python]>=1.0.6",
     "requests>=2.34.2",
+    "markdown>=3.8.1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,16 @@ dependencies = [
     "mkdocs-redirects>=1.2.3",
     "mkdocstrings[python]>=1.0.6",
     "requests>=2.34.2",
-    "markdown>=3.8.1",
 ]
 
 [dependency-groups]
 dev = [
     "prek>=0.4.11",
     "pytest>=9.1.1",
+]
+confluence = [
+    "requests>=2.34.2",
+    "markdown>=3.8.1",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,6 @@ name = "ocs-docs"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "markdown" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-redirects" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -326,6 +325,10 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+confluence = [
+    { name = "markdown" },
+    { name = "requests" },
+]
 dev = [
     { name = "prek" },
     { name = "pytest" },
@@ -333,7 +336,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "markdown", specifier = ">=3.8.1" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.5.3" },
     { name = "mkdocs-redirects", specifier = ">=1.2.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.6" },
@@ -342,6 +344,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+confluence = [
+    { name = "markdown", specifier = ">=3.8.1" },
+    { name = "requests", specifier = ">=2.34.2" },
+]
 dev = [
     { name = "prek", specifier = ">=0.4.11" },
     { name = "pytest", specifier = ">=9.1.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -317,6 +317,7 @@ name = "ocs-docs"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "markdown" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-redirects" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -332,6 +333,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "markdown", specifier = ">=3.8.1" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.5.3" },
     { name = "mkdocs-redirects", specifier = ">=1.2.3" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.6" },


### PR DESCRIPTION
### Background

For the threat when upstream package gets compromised, a malicious version gets published, and **CI or dependabot** pulls this version before community notice and fix.

Similar to OCS Project's supply-chain hardening done in https://github.com/dimagi/open-chat-studio/pull/4119

### Note on Risks 

- Even if small dependency list for this project, there is still a risk - requests alone is one of the most valuable typosquatting/compromise targets in the Python ecosystem, and it's a direct dependency here.
- cooldown only gates Dependabot's own PRs, so a manual uv lock still resolves to whatever was published minutes ago
- Dependabot cooldown does not apply to security updates, so advisory fixes still land immediately.
- GitHub workflows install 3rd party actions and handle secrets, so has risk
- Cooldown delays the PR that bumps a tag; it does nothing when an upstream tag is repointed at malicious code underneath you. 

### Done

1. Added **pre-commit hook updates** in dependabot
2. **Cooldown / release-age gates:** cooldown added to dependabot to delay adopting a newly published version
3. GitHub workflows to use: `uv sync --locked` so dependency installs fail closed on lockfile drift instead of silently re-resolving to a newly published (potentially malicious) package version.
5. In `update_confluence.yml` fixed a latent bug while in there: python-version: "3.12" was below the project's own requires-python = ">=3.13".  Now provision Python solely through astral-sh/setup-uv instead of stating python-version: 3,13
For Workflow consistency - made change to all 5 workflows
6. **Markdown is now declared explicitly in pyproject.toml: not as dependency of requests** -  `markdown` in a new `confluence` group to be used by update-confluence (aim to reduce 
7. Claude Code Review suggestion - Workflow consistency of permissions to `least privilege: default none`, override only if necessary at job level

### How to Test
- permissions have been changed so need to monitor runs of all GitHub action workflows
- `uv sync --locked --only-group confluence`
- `uv sync --locked`
- run `update-confluence.yml` as biggest changes to this 
- Confirm cooldown is honoured for github-actions and pre-commit after merge (Insights → Dependency graph → Dependabot, check for config warnings). 
- Same check would surface whether versioning-strategy: "increase-if-necessary" is accepted on the uv ecosystem — unsupported keys are typically ignored rather than erroring, so a silent no-op wouldn't announce itself. Still no network here to verify the supported-ecosystem list.

### On HOLD, till after review and discussion with developers

Claude Review point 2 - Third-party actions are still floating major tags to fix: SHA-pin every third-party action
