### PR TITLE
docs(widget): add explicit anchors to icon-prefixed headings

### DIFF
--- a/docs/chat_widget/changelog.md
+++ b/docs/chat_widget/changelog.md
@@ -4,7 +4,7 @@
 
 This guide will help you upgrade from previous versions of the Open Chat Studio Widget to the latest version. Please follow these steps carefully to ensure a smooth transition and also review any changes and upgrade steps between your current version and the latest version.
 
-## :octicons-rocket-24: Quick Upgrade Steps
+## :octicons-rocket-24: Quick Upgrade Steps {#quick-upgrade-steps}
 
 ### 1. Update the script tags
 

--- a/docs/chat_widget/reference.md
+++ b/docs/chat_widget/reference.md
@@ -164,7 +164,7 @@ These questions appear as blue-outlined buttons aligned to the right (similar to
 </open-chat-studio-widget>
 ```
 
-## :material-lock: Read-Only Mode
+## :material-lock: Read-Only Mode {#read-only-mode}
 
 Put the widget into a read-only state when your team is unavailable to respond, during maintenance windows, or whenever you need to pause conversations without hiding the widget entirely. Read-only mode is ideal for:
 
@@ -189,7 +189,7 @@ When enabled:
 !!! tip "Tell users why"
     Pair `disabled` with a [banner](#banner) so users understand why they can't send messages, for example to display your support hours or an outage notice.
 
-## :material-bullhorn: Banner
+## :material-bullhorn: Banner {#banner}
 
 Display an always-visible notice above the chat history to communicate information that shouldn't scroll away with the conversation. Banners are useful for:
 

--- a/docs/chat_widget/reference.md
+++ b/docs/chat_widget/reference.md
@@ -49,7 +49,7 @@ open-chat-studio-widget {
 -   :simple-css:{ .sm .middle } See [CSS Styling](styling.md) for more customization options.
 </div>
 
-## :material-shield-key: Embed Authentication
+## :material-shield-key: Embed Authentication {#embed-authentication}
 Secure your embedded widgets with authentication keys for controlled access to specific channels.
 
 ### Overview
@@ -71,7 +71,7 @@ The embed authentication feature allows you to:
 
 When an embed key is provided, it's automatically sent as an `X-Embed-Key` header with all API requests to authenticate the widget instance.
 
-## :material-account: User Identification
+## :material-account: User Identification {#user-identification}
 Control how users are identified across chat sessions to enable personalized experiences and session continuity.
 ### Overview
 The chat widget uses user identification to:
@@ -126,7 +126,7 @@ function updateChatUser(user) {
 }
 ```
 
-## :material-hand-wave: Welcome Messages
+## :material-hand-wave: Welcome Messages {#welcome-messages}
 
 Enhance user experience by displaying personalized greeting messages when the chat opens. These messages appear as bot messages at the beginning of the conversation. Welcome messages are perfect for:
 
@@ -143,7 +143,7 @@ Pass welcome messages as a JSON array string. Each message appears as a separate
 </open-chat-studio-widget>
 ```
 
-## :material-folder-question: Starter Questions
+## :material-folder-question: Starter Questions {#starter-questions}
 
 Accelerate user engagement with pre-defined clickable questions that address common queries. These starter questions help users quickly find what they're looking for without having to type, which improves the user experience. Starter questions are ideal for:
 
@@ -233,7 +233,7 @@ The banner works on its own, or together with `disabled` to explain a read-only 
 </open-chat-studio-widget>
 ```
 
-## :material-paperclip: File Attachments
+## :material-paperclip: File Attachments {#file-attachments}
 Enable users to send files along with their messages. This feature is perfect for support scenarios where users need to share screenshots, documents, or other files.
 
 ```html
@@ -283,7 +283,7 @@ When attachments are sent to the LLM:
 
 See [CSS Styling](styling.md#file-attachments) for customization options
 
-## :material-translate: Internationalization
+## :material-translate: Internationalization {#internationalization}
 
 The chat widget supports multiple languages and custom translations for all UI text elements.
 
@@ -430,7 +430,7 @@ The session data is set to expire after 24 hours. This is also configurable by u
 
     Session persistence works in conjunction with [User Identification](#user-identification). Different users will have separate persistent sessions.
 
-## :material-lightbulb: Page Context
+## :material-lightbulb: Page Context {#page-context}
 
 Pass page-specific context to the bot with each message to enable more personalized and relevant responses. The context is automatically included with every user message and helps the bot understand the current page state and user environment.
 
@@ -510,7 +510,7 @@ widget.pageContext = {
 
     The page context is persisted in the session state on the server side and is accessible via `session_state.remote_context`. See [accessing remote context](../concepts/prompt_variables.md#accessing-remote-context) for more details.
 
-## :material-lightning-bolt: Events
+## :material-lightning-bolt: Events {#events}
 
 The widget dispatches custom events on the `<open-chat-studio-widget>` host element. All events are dispatched with `bubbles: true` and `composed: true`, so they escape the shadow DOM and are catchable anywhere on the host page using standard `addEventListener`.
 
@@ -549,7 +549,7 @@ widget.addEventListener('ocs:message:received', (e) => {
 });
 ```
 
-## :material-clipboard-list: Properties Reference
+## :material-clipboard-list: Properties Reference {#properties-reference}
 
 ### Core Configuration
 


### PR DESCRIPTION
Fixes the 4 pre-existing MD051 link-fragment false positives in docs/chat_widget/reference.md, surfaced while reviewing #668.

markdownlint derives link fragments from the raw heading text, so an emoji-shortcode heading yields #material-lock-read-only-mode. MkDocs Material strips the shortcode when slugifying and renders id=read-only-mode and id=banner, so the links were always correct in the built site.

attr_list is enabled and MD051 honours {#named-anchor}, so the anchors are now pinned explicitly. Rendered heading ids are unchanged, verified in the built HTML.

Verified with: uv run zensical build --clean --strict (No issues found).

Base branch note: per AGENTS.md, docs/chat_widget/ changes normally target widget-develop. This branch is based on main; cherry-pick df40f83 onto widget-develop to move it.

Follow-up to #668.

Generated with [Claude Code](https://claude.ai/code)