### PR TITLE
Document how a node's input is chosen on a merge

### DIFF
--- a/docs/concepts/pipelines/parallel.md
+++ b/docs/concepts/pipelines/parallel.md
@@ -30,7 +30,7 @@ flowchart LR
 See this pattern used in the Workflow Cookbook: [Safety check in parallel](../../how-to/workflow_cookbook.md#safety-check-in-parallel), where an unconnected **safe** output lets compliant messages pass through unchanged.
 
 ## Multiple outputs
-Connecting multiple outputs from one node (e.g. a router node) to the output of another node is allowed. If more than one of the outputs from the node have a value, the first one will be passed to the next node as input.
+Connecting multiple outputs from one node (e.g. a router node) to the output of another node is allowed. If the node produces more than one output over the course of the run, the most recent one is passed on as input — see [Which input a node receives](#which-input-a-node-receives).
 
 ```mermaid
 flowchart LR
@@ -53,6 +53,19 @@ flowchart LR
 
 See this pattern used in the Workflow Cookbook: [Router for classification](../../how-to/workflow_cookbook.md#router-for-classification), where multiple category outputs feed into the same Python node.
 
+## Which input a node receives
+
+A node runs once for every time an upstream branch reaches it. Each run has:
+
+* **`input`** — the output that arrived most recently, i.e. from the branch that triggered this run.
+* **`node_inputs`** — every output that has arrived so far, oldest first. On a node where branches merge this list grows with each run, which is how a node sees more than one branch at once.
+
+Inputs are ordered by when they arrived, never by the order the connections were drawn, so redrawing the same graph does not change what a node receives.
+
+!!! note "Reading the other branches"
+
+    `node_inputs` is available to the [Python node](../../tech-hub/python_node.md#additional-keyword-arguments) as a keyword argument, and to the template and email nodes as `{{ node_inputs }}`. A Python node can also read any completed node by name with `get_node_output("Node Name")`, which is the clearest option when you know which branches you are merging.
+
 ## Uneven branches
 
 Consider the following graph:
@@ -73,7 +86,7 @@ The execution steps are as follows:
 2. `NodeC` and `NodeD` in parallel
 3. `NodeD`
 
-Notice how `NodeD` gets executed twice. The first time `NodeD` runs it will have the output from `NodeC` as it's input. The 2nd time it runs it will have both the outputs from `NodeB` and `NodeC` as its inputs.
+Notice how `NodeD` gets executed twice. The first time it runs, only `NodeB` has reached it, so `NodeB`'s output is its `input` and its single `node_inputs` entry. By the second run `NodeC` has finished, so `NodeC`'s output becomes the `input` and `node_inputs` holds both.
 
 To understand why this happens you need to understand the [execution model](index.md#how-a-pipeline-runs).
 

--- a/docs/tech-hub/python_node.md
+++ b/docs/tech-hub/python_node.md
@@ -23,7 +23,7 @@ The `input` parameter is a string that contains the input to the node. The retur
 
 The following additional arguments are provided:
 
-* `node_inputs: list[str]` - A list of all the inputs to the node at the time of execution. This will be the same as `[input]` except when the node is part of a workflow with [parallel branches](../concepts/pipelines/parallel.md).
+* `node_inputs: list[str]` - All the inputs that have reached the node at the time of execution, oldest first, with `input` as the last entry. This will be the same as `[input]` except when the node is part of a workflow with [parallel branches](../concepts/pipelines/parallel.md#which-input-a-node-receives).
 
 !!! warning
 


### PR DESCRIPTION
Documents which input a node receives when branches merge, and corrects two places where the existing text described behaviour the executor did not have.

- New **Which input a node receives** section: `input` is the output that arrived most recently, `node_inputs` is everything that has arrived so far, and both are ordered by arrival rather than by the order the connections were drawn.
- **Uneven branches**: the first `NodeD` run gets `NodeB`, not `NodeC` — the paragraph contradicted the code sample directly below it, which aborts the first run "since only `NodeB` has outputs".
- **Multiple outputs**: reworded off "the first one will be passed" to the same single rule.
- **Python node**: `node_inputs` described as all arrivals with `input` last, rather than "all the inputs to the node".

:warning: Merge after dimagi/open-chat-studio#4211 is deployed. Until then the platform still resolves inputs by connection order and `node_inputs` never holds more than one entry, so the Option 2 recipe on this page does not work.
