### PR TITLE
[DevOps] Tighten GitHub workflow permissions

### DIFF
--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh release list:*),Bash(gh release view:*),Bash(gh release create:*),Bash(git diff:*),Read
+allowed-tools: Bash(gh release list:*),Bash(gh release create:*),Bash(git diff:*),Read
 description: Create a new release with changelog
 argument-hint: [release-tag] [release-title]
 ---

--- a/.claude/commands/create-release.md
+++ b/.claude/commands/create-release.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh release:*),Bash(git:*),Read
+allowed-tools: Bash(gh release list:*),Bash(gh release view:*),Bash(gh release create:*),Bash(git diff:*),Read
 description: Create a new release with changelog
 argument-hint: [release-tag] [release-title]
 ---

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
+allowed-tools: Task,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
 description: Review a pull request
 ---
 

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Task,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
+allowed-tools: Task,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
 description: Review a pull request
 ---
 
@@ -16,8 +16,8 @@ Then launch the documentation-pr-reviewer agent with context about:
 
 The agent will provide structured feedback following documentation best practices. Only post feedback that is noteworthy and actionable.
 
-Use inline comments via `gh pr comment` for specific line issues.
-Use top-level comments for overall observations.
+Use `mcp__github_inline_comment__create_inline_comment` for feedback tied to a specific file/line.
+Use `gh pr comment` for a top-level summary comment covering overall observations.
 Keep all feedback concise and constructive.
 
 ---

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -47,9 +47,13 @@ Any workflow here triggered by `pull_request` (check the code) is affected: the 
 
 ## Tool Allowlist
 
-The explicit per-run tool allowlist is the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action. Note that the agent frontmatter tool list is **not** the security boundary — the workflow run-level allowlist is
+The explicit per-run tool allowlist is the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
 
-If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — the run won't fail. A missing tool usually surfaces as an incomplete result rather than an error, so check the run transcript for denied tool calls if the output looks truncated.
+Two places can set it. Most workflows pass `--allowedTools` in `claude_args` directly — when present, that's what's enforced. `release.yml` is the exception: its `claude_args` sets no `--allowedTools` at all (only `--model`), so the allowlist instead comes entirely from the invoked command's own frontmatter — `.claude/commands/create-release.md`'s `allowed-tools:`. When editing a command invoked by a workflow with no `--allowedTools` of its own, that command's frontmatter *is* the security boundary; keep it and the workflow in sync for every other case.
+
+!!! note "Warning"
+
+    If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
 
 ## Labels
 

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -47,7 +47,9 @@ Any workflow here triggered by `pull_request` (check the code) is affected: the 
 
 The explicit per-run tool allowlist is the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
 
-Every workflow passes `--allowedTools` in `claude_args` directly — that's what's enforced. Each also invokes a command with its own `allowed-tools:` frontmatter (e.g. `.claude/commands/create-release.md`); keep the two lists in sync, since the command frontmatter is what governs if the command is ever run manually/interactively outside its workflow.
+Every workflow passes `--allowedTools` in `claude_args` directly — that's what's enforced. Some workflows invoke a command with its own `allowed-tools:` frontmatter (e.g. `.claude/commands/create-release.md`), and some of those commands launch a subagent via `Task` with its own `tools:` frontmatter (e.g. `documentation-pr-reviewer`).
+
+None of these further declarations expand what's enforced — only the workflow's `--allowedTools` does — so a tool named further down the chain but missing from the workflow's list is simply unusable there, no matter what the command or agent frontmatter claims. Keep all of these in sync: right now `documentation-pr-reviewer`'s `tools:` includes `WebFetch`/`WebSearch` for link-checking, but neither `claude-review.yml` nor `review-pr.md` grants them, so that capability is currently dead when the agent runs through this pipeline. The command frontmatter is also what governs if a command is ever run manually/interactively outside its workflow.
 
 > [!WARNING]
 > If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.

--- a/.github/workflows/README-claude-workflows.md
+++ b/.github/workflows/README-claude-workflows.md
@@ -1,8 +1,8 @@
 # GitHub Automation with Claude
 
-For engineers responsible for extending, debugging, or operating the GitHub workflows on this user documentation repo. The main OCS project has similar workflows, see [the developer guide on GitHub automation with Claude]](https://developers.openchatstudio.com/developer_guides/claude_github_automation/).
+For engineers responsible for extending, debugging, or operating the GitHub workflows on this user documentation repo. The main OCS project has similar workflows, see [the developer guide on GitHub automation with Claude](https://developers.openchatstudio.com/developer_guides/claude_github_automation/).
 
-These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions. Each run gives Claude access to the repository, a shell, and the GitHub CLI.
+These workflows use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to run Claude Code inside GitHub Actions.
 
 ## GitHub workflows
 
@@ -19,9 +19,7 @@ These workflows use [`anthropics/claude-code-action`](https://github.com/anthrop
 End-to-end view of what each workflow actually does: which Claude command or instruction spec it
 invokes, whether that delegates to a subagent, and what comes out the other end.
 
-Commands live in `.claude/commands/`, agents in `.claude/agents/`. A command is a human-typable slash command
-and is usable from a workflow's `prompt:`. An agent is never invoked directly — only launched by a
-command or, for automation, called straight through the `Task` tool.
+Commands live in `.claude/commands/`, agents in `.claude/agents/` ([background](https://docs.anthropic.com/en/docs/claude-code/sub-agents)).
 
 | Workflow | Command / Instruction Spec | Subagent | Outcome |
 |---|---|---|---|
@@ -49,11 +47,10 @@ Any workflow here triggered by `pull_request` (check the code) is affected: the 
 
 The explicit per-run tool allowlist is the main safeguard against a compromised or malicious prompt (e.g. a hostile issue/PR body) taking unintended action.
 
-Two places can set it. Most workflows pass `--allowedTools` in `claude_args` directly — when present, that's what's enforced. `release.yml` is the exception: its `claude_args` sets no `--allowedTools` at all (only `--model`), so the allowlist instead comes entirely from the invoked command's own frontmatter — `.claude/commands/create-release.md`'s `allowed-tools:`. When editing a command invoked by a workflow with no `--allowedTools` of its own, that command's frontmatter *is* the security boundary; keep it and the workflow in sync for every other case.
+Every workflow passes `--allowedTools` in `claude_args` directly — that's what's enforced. Each also invokes a command with its own `allowed-tools:` frontmatter (e.g. `.claude/commands/create-release.md`); keep the two lists in sync, since the command frontmatter is what governs if the command is ever run manually/interactively outside its workflow.
 
-!!! note "Warning"
-
-    If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
+> [!WARNING]
+> If Claude tries to use a tool that isn't permitted, that call is denied and it continues without it — **the run won't fail**. A missing tool usually surfaces as an **incomplete result rather than an error**, so check the run transcript for denied tool calls if the output looks truncated.
 
 ## Labels
 
@@ -77,7 +74,3 @@ Issues that can show up on any of these workflows. For workflow-specific trouble
 - **Authentication or permission failures:** Verify `ANTHROPIC_API_KEY` is valid. For `claude.yml` and `update-changelog.yml` (which use the `ocs-agent` app), also verify the app's private key matches `OCS_AGENT_PRIVATE_KEY` and the app is still installed on the relevant repo(s).
 - **Output quality needs improvement:** Comment on the generated PR with `@claude` and specify what to revise.
 - **For systemic quality issues:** Update the relevant command or agent in `.claude/commands/` / `.claude/agents/` rather than correcting each PR manually.
-
-## Best Practices
-
-1. [Background to using Claude custom Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -34,7 +34,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
       id-token: write
 
     steps:
@@ -70,7 +69,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "dependabot[bot]"
           claude_args: |
-            --allowedTools "Bash(uv:*),Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Edit,WebFetch,WebSearch"
+            --allowedTools "Bash(uv sync:*),Bash(uv run zensical build:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,WebFetch,WebSearch"
           prompt: |
             You are reviewing PR #${{ steps.pr.outputs.pr_number }}.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
   create-weekly-release:
     permissions:
       contents: write
-      pull-requests: write
-      issues: write
       id-token: write
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           prompt: /create-release ${{ env.RELEASE_TAG }} "${{ env.RELEASE_NAME }}"
           claude_args: |
             --model claude-sonnet-4-6
+            --allowedTools "Bash(gh release list:*),Bash(gh release view:*),Bash(gh release create:*),Bash(git diff:*),Read"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           prompt: /create-release ${{ env.RELEASE_TAG }} "${{ env.RELEASE_NAME }}"
           claude_args: |
             --model claude-sonnet-4-6
-            --allowedTools "Bash(gh release list:*),Bash(gh release view:*),Bash(gh release create:*),Bash(git diff:*),Read"
+            --allowedTools "Bash(gh release list:*),Bash(gh release create:*),Bash(git diff:*),Read"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Background

Documented README for Claude workflows and identified permission that needed tightening

### Reviewer Notes

#### High risk workflow fixes
These are triggered by an attacker - influenceable content (a pr or issue)
1. **`Claude-dependabot review`** workflow tightening of `--allowedTools`
2. Align tool lists for and **`claude-review.yml`** which uses command `review-pr.md `

#### Other fixes

1. **Weekly release summary workflow:** remove write permissions from `release.yml` & align and tighten the allowed tools for this and the `create-release.md` command 
2. **update-api-docs.yml** - removed pull-requests:write as the actual PR creation (peter-evans/create-pull-request@v8,) is given the app-token explicitly
3. **README**: Includes information new maintainer can't get from the Anthropic docs, and they're what makes the Pipelines table readable.



### Questions

1.  **create-release.md** step 3 says "Verify that the links exist before adding" while no WebFetch is granted in either list — which, per this PR's own new WARNING callout, means that instruction silently no-ops every run. Worth a follow-up to either grant the tool or drop the line.